### PR TITLE
feat(logging): redacting logger wrapper (PR 1/4 — agent JWT auth)

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,176 @@
+// Package logging provides a redacting logger wrapper for FaultWall.
+//
+// Security requirement (spec §8.1): Never log tokens, secrets, or credentials.
+// This package wraps the standard library logger with automatic redaction of
+// JWTs, bearer tokens, and other sensitive patterns before emission.
+//
+// Use logging.Printf / logging.Infof / logging.Errorf instead of log.Printf
+// anywhere a message might touch auth material. All auth-package logging
+// MUST go through this wrapper.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Level is the emitted log level.
+type Level int
+
+const (
+	LevelDebug Level = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
+func (l Level) String() string {
+	switch l {
+	case LevelDebug:
+		return "DEBUG"
+	case LevelInfo:
+		return "INFO"
+	case LevelWarn:
+		return "WARN"
+	case LevelError:
+		return "ERROR"
+	default:
+		return "INFO"
+	}
+}
+
+// Logger is a redacting logger that wraps log.Logger.
+// It redacts known secret patterns (JWT, Bearer, keyring passwords) before
+// writing to the underlying sink.
+type Logger struct {
+	mu    sync.Mutex
+	sink  *log.Logger
+	level Level
+}
+
+var (
+	// jwtPattern matches JWT-shaped strings: 3 base64url segments separated by dots.
+	// RFC 7519 JWTs are always 3 segments. Require each segment to be long enough
+	// to avoid false positives on short dotted identifiers (e.g. "a.b.c").
+	jwtPattern = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`)
+
+	// bearerPattern matches "Bearer <token>" in any casing.
+	bearerPattern = regexp.MustCompile(`(?i)\b(bearer)\s+[A-Za-z0-9._~+/=_-]{8,}`)
+
+	// tokenKVPattern matches token=..., password=..., secret=... key/value pairs.
+	// Captures the key so we can preserve it in the redacted output.
+	tokenKVPattern = regexp.MustCompile(`(?i)\b(token|password|secret|api[_-]?key|auth)\s*[:=]\s*("[^"]+"|'[^']+'|[^\s,;}]+)`)
+
+	// pgConnStringPattern matches postgres connection strings that embed a password.
+	// e.g. postgres://user:pass@host/db
+	pgConnStringPattern = regexp.MustCompile(`(postgres(?:ql)?://[^:\s]+):([^@\s]+)@`)
+)
+
+const redacted = "[REDACTED]"
+
+// Redact returns s with known secret patterns replaced by [REDACTED].
+// It is safe to call Redact on any string before logging, even outside this
+// package — e.g. for error messages that may contain user input.
+func Redact(s string) string {
+	if s == "" {
+		return s
+	}
+	s = jwtPattern.ReplaceAllString(s, redacted)
+	s = bearerPattern.ReplaceAllString(s, "$1 "+redacted)
+	s = tokenKVPattern.ReplaceAllStringFunc(s, func(match string) string {
+		// Preserve the key, redact the value.
+		sub := tokenKVPattern.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return redacted
+		}
+		// Find the separator that was actually used (: or =) to keep output faithful.
+		sep := "="
+		if idx := strings.IndexAny(match, ":="); idx >= 0 {
+			sep = string(match[idx])
+		}
+		return sub[1] + sep + redacted
+	})
+	s = pgConnStringPattern.ReplaceAllString(s, "$1:"+redacted+"@")
+	return s
+}
+
+// New returns a Logger writing to the given sink with the given level.
+// If sink is nil, os.Stderr is used.
+func New(sink io.Writer, level Level) *Logger {
+	if sink == nil {
+		sink = os.Stderr
+	}
+	return &Logger{
+		sink:  log.New(sink, "", log.LstdFlags|log.Lmicroseconds),
+		level: level,
+	}
+}
+
+// Default is the package-level logger used by the package-level helpers.
+// Tests may replace it via SetDefault.
+var defaultLogger = New(os.Stderr, LevelInfo)
+
+// SetDefault replaces the package-level default logger. Intended for tests and
+// for main() to configure verbosity/sink at startup.
+func SetDefault(l *Logger) {
+	if l == nil {
+		return
+	}
+	defaultLogger = l
+}
+
+// Default returns the package-level default logger.
+func Default() *Logger {
+	return defaultLogger
+}
+
+// SetLevel updates the minimum level emitted by this logger.
+func (l *Logger) SetLevel(level Level) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.level = level
+}
+
+// logf is the internal entry point — applies redaction, level gate, and emit.
+func (l *Logger) logf(level Level, format string, args ...any) {
+	l.mu.Lock()
+	threshold := l.level
+	l.mu.Unlock()
+	if level < threshold {
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	msg = Redact(msg)
+	l.sink.Printf("[%s] %s", level.String(), msg)
+}
+
+// Debugf logs at DEBUG level after redaction.
+func (l *Logger) Debugf(format string, args ...any) { l.logf(LevelDebug, format, args...) }
+
+// Infof logs at INFO level after redaction.
+func (l *Logger) Infof(format string, args ...any) { l.logf(LevelInfo, format, args...) }
+
+// Warnf logs at WARN level after redaction.
+func (l *Logger) Warnf(format string, args ...any) { l.logf(LevelWarn, format, args...) }
+
+// Errorf logs at ERROR level after redaction.
+func (l *Logger) Errorf(format string, args ...any) { l.logf(LevelError, format, args...) }
+
+// Printf mirrors log.Printf semantics at INFO level, with redaction applied.
+// Exists so call sites doing a mechanical `log.Printf` → `logging.Printf` swap
+// do not need to pick a level.
+func (l *Logger) Printf(format string, args ...any) { l.logf(LevelInfo, format, args...) }
+
+// Package-level conveniences — delegate to defaultLogger.
+// These let callers write `logging.Infof(...)` without threading a logger around.
+
+func Debugf(format string, args ...any) { defaultLogger.Debugf(format, args...) }
+func Infof(format string, args ...any)  { defaultLogger.Infof(format, args...) }
+func Warnf(format string, args ...any)  { defaultLogger.Warnf(format, args...) }
+func Errorf(format string, args ...any) { defaultLogger.Errorf(format, args...) }
+func Printf(format string, args ...any) { defaultLogger.Printf(format, args...) }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,177 @@
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRedact_JWT(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantIn string // substring that MUST appear in output
+		wantNotIn string // substring that must NOT appear
+	}{
+		{
+			name:      "plain jwt",
+			input:     "issued token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZ2VudC0xIn0.abcdefghij for agent",
+			wantIn:    "[REDACTED]",
+			wantNotIn: "eyJhbGci",
+		},
+		{
+			name:      "jwt inside sentence",
+			input:     "agent login failed; token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.signaturepart123",
+			wantIn:    "token=[REDACTED]",
+			wantNotIn: "eyJhbGci",
+		},
+		{
+			name:      "short dotted id is NOT a jwt",
+			input:     "version a.b.c shipped",
+			wantIn:    "version a.b.c shipped",
+			wantNotIn: "[REDACTED]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Redact(tt.input)
+			if !strings.Contains(got, tt.wantIn) {
+				t.Errorf("Redact(%q) = %q; want substring %q", tt.input, got, tt.wantIn)
+			}
+			if tt.wantNotIn != "" && strings.Contains(got, tt.wantNotIn) {
+				t.Errorf("Redact(%q) = %q; must NOT contain %q", tt.input, got, tt.wantNotIn)
+			}
+		})
+	}
+}
+
+func TestRedact_Bearer(t *testing.T) {
+	in := "Authorization: Bearer abc123xyz789deadbeef"
+	out := Redact(in)
+	if strings.Contains(out, "abc123xyz789deadbeef") {
+		t.Errorf("bearer token leaked: %q", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "bearer [redacted]") {
+		t.Errorf("expected 'Bearer [REDACTED]', got %q", out)
+	}
+}
+
+func TestRedact_TokenKV(t *testing.T) {
+	cases := []string{
+		`token=abc12345`,
+		`token: "supersecretvalue"`,
+		`password=hunter2pass`,
+		`api_key=sk-1234567890`,
+		`secret='my-secret-value'`,
+	}
+	for _, in := range cases {
+		out := Redact(in)
+		if !strings.Contains(out, "[REDACTED]") {
+			t.Errorf("Redact(%q) did not redact: %q", in, out)
+		}
+		// The raw value must not appear
+		for _, leak := range []string{"abc12345", "supersecretvalue", "hunter2pass", "sk-1234567890", "my-secret-value"} {
+			if strings.Contains(out, leak) {
+				t.Errorf("Redact(%q) leaked %q in %q", in, leak, out)
+			}
+		}
+	}
+}
+
+func TestRedact_PostgresConnString(t *testing.T) {
+	in := "connecting to postgres://admin:supersecret@db.internal:5432/faultwall now"
+	out := Redact(in)
+	if strings.Contains(out, "supersecret") {
+		t.Errorf("postgres password leaked: %q", out)
+	}
+	if !strings.Contains(out, "postgres://admin:[REDACTED]@") {
+		t.Errorf("expected redacted conn string, got %q", out)
+	}
+}
+
+func TestRedact_EmptyAndBenign(t *testing.T) {
+	if Redact("") != "" {
+		t.Errorf("empty string should pass through unchanged")
+	}
+	benign := "Proxy: accepted connection from 127.0.0.1:54321 agent=cursor-ai"
+	if Redact(benign) != benign {
+		t.Errorf("benign log line was modified: %q", Redact(benign))
+	}
+}
+
+func TestLogger_LevelGate(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf, LevelWarn)
+
+	l.Debugf("should not appear")
+	l.Infof("also should not appear")
+	l.Warnf("should appear")
+	l.Errorf("should also appear")
+
+	out := buf.String()
+	if strings.Contains(out, "should not appear") || strings.Contains(out, "also should not appear") {
+		t.Errorf("below-threshold messages leaked: %q", out)
+	}
+	if !strings.Contains(out, "[WARN] should appear") {
+		t.Errorf("expected WARN message, got %q", out)
+	}
+	if !strings.Contains(out, "[ERROR] should also appear") {
+		t.Errorf("expected ERROR message, got %q", out)
+	}
+}
+
+func TestLogger_RedactsOnEmit(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf, LevelInfo)
+
+	l.Infof("agent logged in with token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZ2VudC0xIn0.verylongsignature")
+
+	out := buf.String()
+	if strings.Contains(out, "eyJhbGci") {
+		t.Fatalf("JWT leaked to log sink: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Fatalf("expected [REDACTED] in log output, got %q", out)
+	}
+}
+
+func TestLogger_PrintfDefaultLevel(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf, LevelInfo)
+	l.Printf("hello %s", "world")
+	if !strings.Contains(buf.String(), "[INFO] hello world") {
+		t.Errorf("Printf should map to INFO, got %q", buf.String())
+	}
+}
+
+func TestDefault_SetAndUse(t *testing.T) {
+	var buf bytes.Buffer
+	orig := Default()
+	defer SetDefault(orig) // restore for other tests
+
+	SetDefault(New(&buf, LevelInfo))
+	Infof("package-level call password=leaky123")
+
+	out := buf.String()
+	if strings.Contains(out, "leaky123") {
+		t.Errorf("package-level default did not redact: %q", out)
+	}
+	if !strings.Contains(out, "password=[REDACTED]") {
+		t.Errorf("expected redacted password, got %q", out)
+	}
+}
+
+func TestSetLevel_Runtime(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf, LevelError)
+	l.Infof("before")
+	l.SetLevel(LevelDebug)
+	l.Debugf("after")
+	out := buf.String()
+	if strings.Contains(out, "before") {
+		t.Errorf("message below original threshold leaked: %q", out)
+	}
+	if !strings.Contains(out, "[DEBUG] after") {
+		t.Errorf("expected DEBUG message after SetLevel, got %q", out)
+	}
+}


### PR DESCRIPTION
First of four PRs implementing agent JWT authentication per the engineering spec (`/tmp/faultwall-agent-auth-spec.md`).

## What this PR does

Adds `internal/logging` — a drop-in logger wrapper that auto-redacts secrets before emission. Spec §8.1 is non-negotiable: **never log tokens**, so we land the redaction machinery *first*, before any JWT handling touches the codebase.

## Redaction patterns

| Pattern | Example input | Output |
|---|---|---|
| JWT | `eyJhbGciOiJIUzI1NiJ9.eyJzdWIi...sig` | `[REDACTED]` |
| Bearer | `Authorization: Bearer abc123...` | `Bearer [REDACTED]` |
| key=value | `token=abc`, `password=hunter2`, `api_key=sk-...`, `secret='...'` | `token=[REDACTED]`, etc. |
| Postgres conn | `postgres://admin:pw@host/db` | `postgres://admin:[REDACTED]@host/db` |

## API

```go
import \"github.com/shreyasXV/faultwall/internal/logging\"

logging.Infof(\"agent %s logged in\", agentID)             // package-level
l := logging.New(os.Stderr, logging.LevelDebug)             // instance
l.Debugf(\"token payload: %s\", tokenString)                // auto-redacted
```

Mirrors `log.Printf` semantics (via `logging.Printf` at INFO) so migrating existing call sites in PR 3 is a mechanical swap.

## Testing

- ✅ 10 tests covering each redaction pattern, level gating, default logger, and `SetLevel` at runtime
- ✅ `go vet ./internal/logging/...` clean
- ✅ `go build .` (full binary) compiles
- ✅ Zero new external deps — stdlib only

Short-ID false-positive test (`a.b.c` is NOT redacted as JWT) explicitly included.

## Sequence

1. **This PR** — redacting logger (foundation, no callers yet)
2. SQLite state layer (`internal/store/`) — agent store + JTI denylist
3. JWT sign/verify + startup packet wiring (`internal/auth/`) — migrates existing `log.Printf` sites touching auth
4. cobra CLI refactor + `admin`/`agent` subcommands

## Review focus

- Regex patterns in \`logging.go\` — any known secret shape missing?
- \`LevelWarn\` default vs \`LevelInfo\` for production binaries?

Target: YC S26 (May 4).

🤖 Written and tested by ShreyClaw, reviewed by Hermes.