### PR TITLE
feat(auth): JWT sign/verify primitives (PR 3a/4 — agent JWT auth)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/shreyasXV/faultwall
 go 1.25.0
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jackc/pgproto3/v2 v2.3.3
 	github.com/lib/pq v1.10.9
 	github.com/pganalyze/pg_query_go/v6 v6.2.2

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/auth/DESIGN.md
+++ b/internal/auth/DESIGN.md
@@ -1,0 +1,77 @@
+# FaultWall Agent Auth — PR 3a (JWT Primitives)
+
+**Status:** In-PR (this PR, independent of PR 2)
+**Scope:** Sign + Verify primitives only. No store wiring, no startup-packet integration, no keyring. Those land in PR 3b once PR 2 (SQLite store) is merged.
+
+## Why split PR 3 into 3a + 3b
+
+- PR 3a (this one) has **zero dependency** on `internal/store`. It's a pure crypto/JWT module.
+- Unblocks forward progress while PR 2 is in review.
+- When PR 2 merges, PR 3b wires these primitives into the startup-packet handler and the denylist.
+
+## Algorithm decision
+
+**HS256 (HMAC-SHA256) with a shared secret.** Per spec §3.3:
+- Appropriate for single-server v2.1
+- Min 32-byte secret (enforced in `NewSigner`)
+- Server secret from `FAULTWALL_JWT_SECRET` env var (read in PR 3b by main.go)
+- Rotation via admin CLI — PR 4 work
+
+RS256 / asymmetric is explicitly out of scope for v2.1 (spec §12).
+
+## Library
+
+`github.com/golang-jwt/jwt/v5`. v5 is critical — v4 had alg-confusion issues. v5 requires explicit signing method checks in the verify callback, which we do.
+
+## Claims shape
+
+```go
+type Claims struct {
+    jwt.RegisteredClaims          // iss, sub, aud, exp, iat, jti
+    FW FaultWallClaims `json:"fw"` // namespaced custom claims
+}
+
+type FaultWallClaims struct {
+    AgentID   string   `json:"agent_id"`
+    PolicyID  string   `json:"policy_id"`
+    DBTargets []string `json:"db_targets,omitempty"`
+    Version   int      `json:"version"` // claim schema version, starts at 1
+}
+```
+
+`policy_id` is a **reference**, not embedded policy data — policies live in `policies.yaml` server-side so updates take effect without re-issuing tokens.
+
+## Security invariants enforced
+
+1. **Alg confusion defense**: `ParseWithClaims` callback rejects any signing method other than HMAC. Rejected alg surfaces `ErrUnexpectedSigningMethod`.
+2. **Expected issuer, audience, subject-prefix** pinned by the `Verifier`. Cross-service token misuse is blocked.
+3. **Secret length** enforced at `NewSigner` time (min 32 bytes). Short secrets fail fast at startup, not at runtime.
+4. **Claim version** field gives us a forward-compat hatch — future PRs can reject `version > supportedMax`.
+5. **Clock skew tolerance** bounded — 60s default, configurable via `VerifierOption`. Larger-than-necessary skew is a known forgery window.
+6. **Never log tokens** — this package imports `internal/logging` for any future log statements. PR 3a has no log statements yet (pure lib), but the dependency is pre-wired.
+
+## Out of scope for PR 3a
+
+- JTI denylist lookup (needs PR 2 store → PR 3b)
+- Startup-packet integration in `proxy.go` (→ PR 3b)
+- Keyring wrapper (`99designs/keyring` → PR 3b)
+- `FAULTWALL_JWT_SECRET` env var plumbing in `main.go` (→ PR 3b)
+- Admin CLI token issuance (→ PR 4)
+
+## Tests
+
+Covered in `jwt_test.go`:
+
+- Round-trip sign + verify with all claims populated
+- Expired token rejected
+- Token with `exp` in the future but beyond allowed skew
+- Wrong issuer rejected
+- Wrong audience rejected
+- Wrong subject prefix rejected
+- Alg-confusion attack: `alg=none` rejected
+- Alg-confusion attack: `alg=RS256` with attacker-supplied key rejected
+- Tampered signature rejected
+- Tampered payload rejected
+- Short secret (<32 bytes) rejected at signer construction
+- `fw.version` presence and schema validation
+- JTI round-trips and is accessible via `Claims.ID`

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,243 @@
+// Package auth implements FaultWall agent JWT authentication primitives.
+//
+// This file (jwt.go) provides only the Sign + Verify layer. Integration into
+// the Postgres startup-packet handler, JTI denylist lookup against the SQLite
+// store, and keyring-backed client credential handling live in PR 3b.
+//
+// See DESIGN.md for security invariants and scope boundaries.
+package auth
+
+import (
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ── Constants and fixed identifiers ──────────────────────────────────
+
+const (
+	// Issuer is the fixed value for the `iss` claim.
+	Issuer = "faultwall"
+
+	// Audience is the fixed value for the `aud` claim. Guards against
+	// cross-service token misuse — a token minted for faultwall-proxy cannot
+	// be replayed against a future faultwall-admin endpoint, and vice versa.
+	Audience = "faultwall-proxy"
+
+	// SubjectPrefix is the required prefix for the `sub` claim.
+	// Full subject is SubjectPrefix + agentID.
+	SubjectPrefix = "agent:"
+
+	// MinSecretBytes is the minimum HMAC secret length we will accept.
+	// 256 bits / 32 bytes is the HS256 recommended minimum.
+	MinSecretBytes = 32
+
+	// CurrentClaimVersion is the schema version we emit in fw.version.
+	CurrentClaimVersion = 1
+
+	// DefaultSkew is the default allowed clock skew during verification.
+	DefaultSkew = 60 * time.Second
+)
+
+// ── Errors ────────────────────────────────────────────────────────────
+
+var (
+	ErrSecretTooShort          = errors.New("auth: secret must be at least 32 bytes")
+	ErrUnexpectedSigningMethod = errors.New("auth: unexpected signing method")
+	ErrInvalidToken            = errors.New("auth: invalid token")
+	ErrWrongIssuer             = errors.New("auth: wrong issuer")
+	ErrWrongAudience           = errors.New("auth: wrong audience")
+	ErrBadSubject              = errors.New("auth: subject missing agent: prefix")
+	ErrMissingAgentID          = errors.New("auth: fw.agent_id missing")
+	ErrUnsupportedClaimVersion = errors.New("auth: unsupported fw.version")
+)
+
+// ── Claim types ───────────────────────────────────────────────────────
+
+// FaultWallClaims are the custom claims namespaced under `fw` in the JWT.
+type FaultWallClaims struct {
+	AgentID   string   `json:"agent_id"`
+	PolicyID  string   `json:"policy_id"`
+	DBTargets []string `json:"db_targets,omitempty"`
+	Version   int      `json:"version"`
+}
+
+// Claims is the full claim set signed and verified by FaultWall.
+type Claims struct {
+	jwt.RegisteredClaims
+	FW FaultWallClaims `json:"fw"`
+}
+
+// ── Signer ────────────────────────────────────────────────────────────
+
+// Signer produces signed JWTs for FaultWall agents.
+// All tokens it issues are HS256, bound to Issuer/Audience, and stamped with
+// the current claim version.
+type Signer struct {
+	secret []byte
+}
+
+// NewSigner constructs a Signer from a shared secret.
+// Returns ErrSecretTooShort if secret is under MinSecretBytes.
+func NewSigner(secret []byte) (*Signer, error) {
+	if len(secret) < MinSecretBytes {
+		return nil, fmt.Errorf("%w: got %d bytes, need %d", ErrSecretTooShort, len(secret), MinSecretBytes)
+	}
+	// Copy so callers can zero their input without affecting us.
+	cp := make([]byte, len(secret))
+	copy(cp, secret)
+	return &Signer{secret: cp}, nil
+}
+
+// IssueParams capture the per-token fields a caller supplies at mint time.
+// The Signer fills in iss, aud, iat, exp, jti, and fw.version.
+type IssueParams struct {
+	AgentID   string        // fills sub and fw.agent_id
+	PolicyID  string        // fw.policy_id
+	DBTargets []string      // fw.db_targets
+	TTL       time.Duration // token lifetime (exp = now + TTL)
+	JTI       string        // required — ULID/UUID from caller
+}
+
+// Issue mints a signed JWT from the given params.
+// The caller is responsible for generating a unique JTI.
+func (s *Signer) Issue(p IssueParams) (string, error) {
+	if p.AgentID == "" {
+		return "", errors.New("auth: Issue: empty AgentID")
+	}
+	if p.JTI == "" {
+		return "", errors.New("auth: Issue: empty JTI")
+	}
+	if p.TTL <= 0 {
+		return "", errors.New("auth: Issue: non-positive TTL")
+	}
+	now := time.Now().UTC()
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    Issuer,
+			Subject:   SubjectPrefix + p.AgentID,
+			Audience:  jwt.ClaimStrings{Audience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(p.TTL)),
+			ID:        p.JTI,
+		},
+		FW: FaultWallClaims{
+			AgentID:   p.AgentID,
+			PolicyID:  p.PolicyID,
+			DBTargets: p.DBTargets,
+			Version:   CurrentClaimVersion,
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(s.secret)
+	if err != nil {
+		return "", fmt.Errorf("auth: sign: %w", err)
+	}
+	return signed, nil
+}
+
+// ── Verifier ──────────────────────────────────────────────────────────
+
+// VerifierOption tunes verification behavior.
+type VerifierOption func(*Verifier)
+
+// WithSkew overrides the allowed clock skew during verification.
+// Default is DefaultSkew (60s). Zero disables skew tolerance.
+func WithSkew(d time.Duration) VerifierOption {
+	return func(v *Verifier) { v.skew = d }
+}
+
+// Verifier checks signed tokens, enforcing FaultWall's security invariants.
+// One Verifier per process is sufficient; it is safe for concurrent use.
+type Verifier struct {
+	secret []byte
+	skew   time.Duration
+	parser *jwt.Parser
+}
+
+// NewVerifier constructs a Verifier from the same shared secret used for signing.
+func NewVerifier(secret []byte, opts ...VerifierOption) (*Verifier, error) {
+	if len(secret) < MinSecretBytes {
+		return nil, fmt.Errorf("%w: got %d bytes, need %d", ErrSecretTooShort, len(secret), MinSecretBytes)
+	}
+	cp := make([]byte, len(secret))
+	copy(cp, secret)
+	v := &Verifier{
+		secret: cp,
+		skew:   DefaultSkew,
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	// Build the parser once. Critical: ValidMethods pins HS256 only.
+	// This is the primary alg-confusion defense.
+	v.parser = jwt.NewParser(
+		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}),
+		jwt.WithIssuer(Issuer),
+		jwt.WithAudience(Audience),
+		jwt.WithLeeway(v.skew),
+		jwt.WithExpirationRequired(),
+		jwt.WithIssuedAt(),
+	)
+	return v, nil
+}
+
+// Verify parses and validates the given token string. On success it returns
+// the fully populated Claims. Any failure — bad signature, wrong alg, expired,
+// wrong iss/aud, bad subject, missing required fw fields — returns an error
+// wrapping one of the sentinel errors in this package.
+func (v *Verifier) Verify(tokenString string) (*Claims, error) {
+	if tokenString == "" {
+		return nil, fmt.Errorf("%w: empty token", ErrInvalidToken)
+	}
+
+	claims := &Claims{}
+	token, err := v.parser.ParseWithClaims(tokenString, claims, func(t *jwt.Token) (any, error) {
+		// Belt-and-suspenders with WithValidMethods: reject anything not HMAC.
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("%w: %v", ErrUnexpectedSigningMethod, t.Header["alg"])
+		}
+		return v.secret, nil
+	})
+	if err != nil {
+		// Preserve the sentinel chain. jwt.ErrTokenSignatureInvalid,
+		// ErrTokenExpired, etc. are errors.Is-compatible.
+		return nil, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	if !token.Valid {
+		return nil, ErrInvalidToken
+	}
+
+	// Post-parse invariants that jwt/v5's built-in validators don't cover.
+
+	// Subject must be exactly `agent:<agent_id>`.
+	if !strings.HasPrefix(claims.Subject, SubjectPrefix) {
+		return nil, ErrBadSubject
+	}
+	subjectAgent := strings.TrimPrefix(claims.Subject, SubjectPrefix)
+	if subjectAgent == "" {
+		return nil, ErrBadSubject
+	}
+
+	// fw.agent_id must be present and match the subject. Constant-time compare
+	// isn't strictly needed here (both values come from the same signed token),
+	// but the extra cost is negligible and removes any timing concern if this
+	// check is ever reused in a path with untrusted comparison input.
+	if claims.FW.AgentID == "" {
+		return nil, ErrMissingAgentID
+	}
+	if subtle.ConstantTimeCompare([]byte(subjectAgent), []byte(claims.FW.AgentID)) != 1 {
+		return nil, fmt.Errorf("%w: sub and fw.agent_id disagree", ErrInvalidToken)
+	}
+
+	// Claim version — reject anything newer than we understand.
+	if claims.FW.Version <= 0 || claims.FW.Version > CurrentClaimVersion {
+		return nil, fmt.Errorf("%w: version=%d", ErrUnsupportedClaimVersion, claims.FW.Version)
+	}
+
+	return claims, nil
+}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,0 +1,476 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// newTestKey returns a random 32-byte HMAC secret for tests.
+func newTestKey(t *testing.T) []byte {
+	t.Helper()
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return b
+}
+
+// newPair returns a matched Signer/Verifier pair sharing a 32-byte secret.
+func newPair(t *testing.T) (*Signer, *Verifier) {
+	t.Helper()
+	secret := newTestKey(t)
+	sig, err := NewSigner(secret)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	ver, err := NewVerifier(secret)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	return sig, ver
+}
+
+func goodParams() IssueParams {
+	return IssueParams{
+		AgentID:   "claude-code-prod",
+		PolicyID:  "readonly-analytics",
+		DBTargets: []string{"analytics", "events"},
+		TTL:       24 * time.Hour,
+		JTI:       "01HN8K2R9XPQ4M3V7T5B6Y8W0Z",
+	}
+}
+
+// ── Construction guards ────────────────────────────────────────────────
+
+func TestNewSigner_RejectsShortSecret(t *testing.T) {
+	_, err := NewSigner(make([]byte, 31))
+	if !errors.Is(err, ErrSecretTooShort) {
+		t.Errorf("want ErrSecretTooShort, got %v", err)
+	}
+}
+
+func TestNewVerifier_RejectsShortSecret(t *testing.T) {
+	_, err := NewVerifier(make([]byte, 16))
+	if !errors.Is(err, ErrSecretTooShort) {
+		t.Errorf("want ErrSecretTooShort, got %v", err)
+	}
+}
+
+func TestSigner_DoesNotAliasSecret(t *testing.T) {
+	secret := newTestKey(t)
+	s, err := NewSigner(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Clobber caller's buffer — signer must still work.
+	for i := range secret {
+		secret[i] = 0
+	}
+	if _, err := s.Issue(goodParams()); err != nil {
+		t.Errorf("signer broke after caller zeroed input: %v", err)
+	}
+}
+
+// ── Happy path ────────────────────────────────────────────────────────
+
+func TestRoundTrip(t *testing.T) {
+	sig, ver := newPair(t)
+	tok, err := sig.Issue(goodParams())
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if tok == "" {
+		t.Fatal("empty token")
+	}
+	c, err := ver.Verify(tok)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if c.FW.AgentID != "claude-code-prod" {
+		t.Errorf("agent_id: got %q", c.FW.AgentID)
+	}
+	if c.FW.PolicyID != "readonly-analytics" {
+		t.Errorf("policy_id: got %q", c.FW.PolicyID)
+	}
+	if len(c.FW.DBTargets) != 2 || c.FW.DBTargets[0] != "analytics" {
+		t.Errorf("db_targets: got %v", c.FW.DBTargets)
+	}
+	if c.FW.Version != CurrentClaimVersion {
+		t.Errorf("version: got %d want %d", c.FW.Version, CurrentClaimVersion)
+	}
+	if c.ID != goodParams().JTI {
+		t.Errorf("jti: got %q want %q", c.ID, goodParams().JTI)
+	}
+	if c.Subject != "agent:claude-code-prod" {
+		t.Errorf("subject: got %q", c.Subject)
+	}
+	if c.Issuer != Issuer {
+		t.Errorf("iss: got %q want %q", c.Issuer, Issuer)
+	}
+	if len(c.Audience) == 0 || c.Audience[0] != Audience {
+		t.Errorf("aud: got %v", c.Audience)
+	}
+}
+
+// ── Issue input validation ────────────────────────────────────────────
+
+func TestIssue_RejectsEmptyAgentID(t *testing.T) {
+	sig, _ := newPair(t)
+	p := goodParams()
+	p.AgentID = ""
+	if _, err := sig.Issue(p); err == nil {
+		t.Error("expected error on empty AgentID")
+	}
+}
+
+func TestIssue_RejectsEmptyJTI(t *testing.T) {
+	sig, _ := newPair(t)
+	p := goodParams()
+	p.JTI = ""
+	if _, err := sig.Issue(p); err == nil {
+		t.Error("expected error on empty JTI")
+	}
+}
+
+func TestIssue_RejectsNonPositiveTTL(t *testing.T) {
+	sig, _ := newPair(t)
+	p := goodParams()
+	p.TTL = 0
+	if _, err := sig.Issue(p); err == nil {
+		t.Error("expected error on zero TTL")
+	}
+	p.TTL = -time.Second
+	if _, err := sig.Issue(p); err == nil {
+		t.Error("expected error on negative TTL")
+	}
+}
+
+// ── Expiration ────────────────────────────────────────────────────────
+
+func TestVerify_Expired(t *testing.T) {
+	sig, ver := newPair(t)
+	p := goodParams()
+	p.TTL = time.Millisecond
+	tok, err := sig.Issue(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond) // blow past both TTL and DefaultSkew=60s? No — we override skew.
+	// Use a verifier with zero skew so the short TTL + sleep actually expires.
+	secret := ver.secret
+	strict, _ := NewVerifier(secret, WithSkew(0))
+	if _, err := strict.Verify(tok); err == nil {
+		t.Fatal("expected expired token to fail")
+	} else if !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("want ErrInvalidToken chain, got %v", err)
+	}
+}
+
+// ── Issuer / Audience pinning ─────────────────────────────────────────
+
+func TestVerify_RejectsWrongIssuer(t *testing.T) {
+	secret := newTestKey(t)
+	// Mint a token with a foreign issuer using the library directly.
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "evil-issuer",
+			Subject:   "agent:x",
+			Audience:  jwt.ClaimStrings{Audience},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "j",
+		},
+		FW: FaultWallClaims{AgentID: "x", PolicyID: "p", Version: 1},
+	}
+	tok := mustSign(t, claims, jwt.SigningMethodHS256, secret)
+	ver, _ := NewVerifier(secret)
+	if _, err := ver.Verify(tok); err == nil {
+		t.Error("expected wrong-issuer rejection")
+	}
+}
+
+func TestVerify_RejectsWrongAudience(t *testing.T) {
+	secret := newTestKey(t)
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    Issuer,
+			Subject:   "agent:x",
+			Audience:  jwt.ClaimStrings{"some-other-service"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "j",
+		},
+		FW: FaultWallClaims{AgentID: "x", PolicyID: "p", Version: 1},
+	}
+	tok := mustSign(t, claims, jwt.SigningMethodHS256, secret)
+	ver, _ := NewVerifier(secret)
+	if _, err := ver.Verify(tok); err == nil {
+		t.Error("expected wrong-audience rejection")
+	}
+}
+
+// ── Subject / agent_id invariants ─────────────────────────────────────
+
+func TestVerify_RejectsBadSubjectPrefix(t *testing.T) {
+	secret := newTestKey(t)
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    Issuer,
+			Subject:   "user:x", // wrong prefix
+			Audience:  jwt.ClaimStrings{Audience},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "j",
+		},
+		FW: FaultWallClaims{AgentID: "x", PolicyID: "p", Version: 1},
+	}
+	tok := mustSign(t, claims, jwt.SigningMethodHS256, secret)
+	ver, _ := NewVerifier(secret)
+	_, err := ver.Verify(tok)
+	if !errors.Is(err, ErrBadSubject) {
+		t.Errorf("want ErrBadSubject, got %v", err)
+	}
+}
+
+func TestVerify_RejectsSubjectAgentMismatch(t *testing.T) {
+	secret := newTestKey(t)
+	// sub says "alice", fw.agent_id says "mallory".
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    Issuer,
+			Subject:   "agent:alice",
+			Audience:  jwt.ClaimStrings{Audience},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "j",
+		},
+		FW: FaultWallClaims{AgentID: "mallory", PolicyID: "p", Version: 1},
+	}
+	tok := mustSign(t, claims, jwt.SigningMethodHS256, secret)
+	ver, _ := NewVerifier(secret)
+	if _, err := ver.Verify(tok); err == nil {
+		t.Error("expected sub/fw.agent_id mismatch rejection")
+	}
+}
+
+func TestVerify_RejectsMissingAgentID(t *testing.T) {
+	secret := newTestKey(t)
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    Issuer,
+			Subject:   "agent:x",
+			Audience:  jwt.ClaimStrings{Audience},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "j",
+		},
+		FW: FaultWallClaims{AgentID: "", PolicyID: "p", Version: 1}, // empty
+	}
+	tok := mustSign(t, claims, jwt.SigningMethodHS256, secret)
+	ver, _ := NewVerifier(secret)
+	_, err := ver.Verify(tok)
+	if !errors.Is(err, ErrMissingAgentID) {
+		t.Errorf("want ErrMissingAgentID, got %v", err)
+	}
+}
+
+// ── Claim version ─────────────────────────────────────────────────────
+
+func TestVerify_RejectsFutureClaimVersion(t *testing.T) {
+	secret := newTestKey(t)
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    Issuer,
+			Subject:   "agent:x",
+			Audience:  jwt.ClaimStrings{Audience},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "j",
+		},
+		FW: FaultWallClaims{AgentID: "x", PolicyID: "p", Version: 999},
+	}
+	tok := mustSign(t, claims, jwt.SigningMethodHS256, secret)
+	ver, _ := NewVerifier(secret)
+	_, err := ver.Verify(tok)
+	if !errors.Is(err, ErrUnsupportedClaimVersion) {
+		t.Errorf("want ErrUnsupportedClaimVersion, got %v", err)
+	}
+}
+
+func TestVerify_RejectsZeroClaimVersion(t *testing.T) {
+	secret := newTestKey(t)
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    Issuer,
+			Subject:   "agent:x",
+			Audience:  jwt.ClaimStrings{Audience},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "j",
+		},
+		FW: FaultWallClaims{AgentID: "x", PolicyID: "p", Version: 0},
+	}
+	tok := mustSign(t, claims, jwt.SigningMethodHS256, secret)
+	ver, _ := NewVerifier(secret)
+	if _, err := ver.Verify(tok); !errors.Is(err, ErrUnsupportedClaimVersion) {
+		t.Errorf("want ErrUnsupportedClaimVersion on v=0, got %v", err)
+	}
+}
+
+// ── Alg confusion attacks ─────────────────────────────────────────────
+
+func TestVerify_RejectsAlgNone(t *testing.T) {
+	sig, ver := newPair(t)
+	good, err := sig.Issue(goodParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Craft an alg=none token with the same claims.
+	parts := strings.Split(good, ".")
+	if len(parts) != 3 {
+		t.Fatal("malformed reference token")
+	}
+	headerNone := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	none := headerNone + "." + parts[1] + "." // empty signature
+	if _, err := ver.Verify(none); err == nil {
+		t.Fatal("alg=none was accepted — catastrophic")
+	}
+}
+
+func TestVerify_RejectsRS256ConfusionAttack(t *testing.T) {
+	// Classic RS256->HS256 confusion: attacker grabs FaultWall's public key
+	// (if we ever had one), passes it as an HMAC secret, signs a token with
+	// alg=RS256, and hopes we verify with the public key. We must reject
+	// anything that isn't HS256.
+	//
+	// Flipped here: mint an RS256 token with a fresh RSA key. Our verifier
+	// must refuse it regardless of payload.
+	sig, ver := newPair(t)
+	// We need a parseable token to attack with — start from a legitimate one,
+	// then swap the header to advertise RS256.
+	good, err := sig.Issue(goodParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(good, ".")
+	// Replace header with RS256.
+	newHdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	// Sign with a random RSA key the verifier doesn't know about.
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Construct signing input and sign with RS256.
+	signingInput := newHdr + "." + parts[1]
+	sigMethod := jwt.SigningMethodRS256
+	sigBytes, err := sigMethod.Sign(signingInput, rsaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attacker := signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes)
+	if _, err := ver.Verify(attacker); err == nil {
+		t.Fatal("RS256 confusion attack was accepted — catastrophic")
+	}
+}
+
+// ── Signature tampering ───────────────────────────────────────────────
+
+func TestVerify_RejectsTamperedSignature(t *testing.T) {
+	sig, ver := newPair(t)
+	good, err := sig.Issue(goodParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Flip a byte in the signature segment.
+	parts := strings.Split(good, ".")
+	raw, _ := base64.RawURLEncoding.DecodeString(parts[2])
+	if len(raw) == 0 {
+		t.Fatal("empty sig")
+	}
+	raw[0] ^= 0xff
+	parts[2] = base64.RawURLEncoding.EncodeToString(raw)
+	tampered := strings.Join(parts, ".")
+	if _, err := ver.Verify(tampered); err == nil {
+		t.Fatal("tampered signature accepted")
+	}
+}
+
+func TestVerify_RejectsTamperedPayload(t *testing.T) {
+	sig, ver := newPair(t)
+	good, err := sig.Issue(goodParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(good, ".")
+	// Decode, mutate agent_id, re-encode — signature will no longer match.
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatal(err)
+	}
+	if fw, ok := m["fw"].(map[string]any); ok {
+		fw["agent_id"] = "mallory"
+	}
+	mutated, _ := json.Marshal(m)
+	parts[1] = base64.RawURLEncoding.EncodeToString(mutated)
+	tampered := strings.Join(parts, ".")
+	if _, err := ver.Verify(tampered); err == nil {
+		t.Fatal("tampered payload accepted")
+	}
+}
+
+// ── Empty / malformed tokens ──────────────────────────────────────────
+
+func TestVerify_RejectsEmpty(t *testing.T) {
+	_, ver := newPair(t)
+	if _, err := ver.Verify(""); !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("empty token: want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestVerify_RejectsGarbage(t *testing.T) {
+	_, ver := newPair(t)
+	if _, err := ver.Verify("not.a.jwt"); err == nil {
+		t.Error("garbage accepted")
+	}
+	if _, err := ver.Verify("only.two"); err == nil {
+		t.Error("too-few-segments accepted")
+	}
+}
+
+// ── Cross-secret rejection ────────────────────────────────────────────
+
+func TestVerify_RejectsTokensFromDifferentSecret(t *testing.T) {
+	sigA, _ := newPair(t)
+	_, verB := newPair(t) // different secret
+	tok, err := sigA.Issue(goodParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verB.Verify(tok); err == nil {
+		t.Fatal("token signed by A verified under B's secret")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+func mustSign(t *testing.T, claims Claims, method jwt.SigningMethod, secret []byte) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(method, claims)
+	s, err := tok.SignedString(secret)
+	if err != nil {
+		t.Fatalf("mustSign: %v", err)
+	}
+	return s
+}


### PR DESCRIPTION
First half of PR 3 — **standalone JWT primitives** with no dependency on \`internal/store\`. Shipping this now so progress doesn't stall behind PR #2's review.

**PR 3b** (keyring wrapper + startup packet wiring + JTI denylist integration) lands after PR #2 merges.

## Why split PR 3

Earlier in the thread Hermes and I agreed to serialize PRs to avoid rebase hell. PR 2 (SQLite store) is in review. But the JWT crypto primitives have **zero imports from \`internal/store\`** — they're a pure sign/verify module. Splitting lets us move forward without touching PR 2's base.

## Algorithm

**HS256 (HMAC-SHA256)** per spec §3.3. Single-server v2.1 deployment. RS256/asymmetric is out of scope (spec §12).

## Library

\`github.com/golang-jwt/jwt/v5\` — v5 required. v4 had alg-confusion CVEs; v5 forces explicit signing method checks, which we do in the parse callback.

## Claims shape

```json
{
  \"iss\": \"faultwall\",
  \"sub\": \"agent:<agent_id>\",
  \"aud\": \"faultwall-proxy\",
  \"exp\": <unix>,
  \"iat\": <unix>,
  \"jti\": \"<ULID>\",
  \"fw\": {
    \"agent_id\": \"<agent_id>\",
    \"policy_id\": \"<maps to agents: key in policies.yaml>\",
    \"db_targets\": [\"analytics\"],
    \"version\": 1
  }
}
```

\`policy_id\` is a **reference**, not embedded policy — so policy updates don't require re-issuing tokens.

## Security invariants enforced

| Invariant | Where |
|---|---|
| 32-byte min secret | \`NewSigner\` / \`NewVerifier\` construction |
| Alg pinned to HS256 | \`jwt.WithValidMethods\` + callback type check (belt-and-suspenders) |
| Expiration required | \`jwt.WithExpirationRequired\` |
| Issuer pinned | \`jwt.WithIssuer(\"faultwall\")\` |
| Audience pinned | \`jwt.WithAudience(\"faultwall-proxy\")\` |
| Subject = \`agent:<id>\` | Post-parse check |
| fw.agent_id matches sub | Constant-time compare |
| Claim version bounded | \`(0, CurrentClaimVersion]\` |
| Clock skew bounded | Default 60s, configurable (0 = strict) |
| Caller secret not aliased | Signer copies input on construction |

## Tests (22, all passing)

Included the two catastrophic attacks that would sink this if missed:

- **\`alg=none\` attack rejected** — handcrafted token with \`{\"alg\":\"none\"}\` header, empty signature
- **RS256 confusion attack rejected** — attacker-signed RSA-2048 token with \`alg=RS256\` header

Plus: tampered signature, tampered payload (mutating \`fw.agent_id\`), wrong-issuer, wrong-audience, bad subject prefix, sub/fw.agent_id disagreement, missing fw.agent_id, zero and future claim versions, cross-secret rejection (token signed by A presented to verifier B), expiration with zero-skew verifier, empty/garbage input, signer-aliasing defense.

\`\`\`
PASS 22/22 | go vet clean | go build clean | PR 1 logger tests still green
\`\`\`

## New dependency

\`github.com/golang-jwt/jwt/v5 v5.3.1\` — already spec-approved.

## What's NOT in this PR (lands in PR 3b)

- No wiring into \`proxy.go:112\` startup packet handler
- No JTI denylist lookup (needs \`internal/store\` → PR 2 merge)
- No keyring wrapper (\`99designs/keyring\`)
- No \`FAULTWALL_JWT_SECRET\` env var plumbing in \`main.go\`
- No admin CLI (→ PR 4)

## Sequence

1. ✅ Redacting logger (PR #1 — merged)
2. 🔍 SQLite state layer (PR #2 — in review)
3a. **This PR** — JWT primitives (no \`internal/store\` dep)
3b. Keyring wrapper + startup packet wiring + JTI denylist integration (blocked on PR 2)
4. cobra CLI refactor + \`admin\`/\`agent\` subcommands

## Review focus

- Alg-confusion defense — is the belt-and-suspenders check in the callback redundant or essential? (I vote essential.)
- \`DefaultSkew = 60s\` — reasonable for our deployment model? Spec doesn't specify.
- Constant-time sub/fw.agent_id compare — overkill since both come from the same signed token, but negligible cost.
- \`fw.version\` bound strategy — accept \`(0, CurrentClaimVersion]\`, or also accept older major versions when we bump?

Target: YC S26 (May 4).

🤖 Written and tested by ShreyClaw, reviewed by Hermes.