### PR TITLE
fix(proxy): implement Postgres SSLRequest handshake for upstream TLS

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -25,6 +25,54 @@ const (
 	colorBold   = "\033[1m"
 )
 
+// dialUpstream connects to the upstream Postgres, performing SSLRequest
+// negotiation when tlsConfig is non-nil (required by RDS/Aurora/Cloud SQL/etc).
+func dialUpstream(upstreamAddr string, tlsConfig *tls.Config) (net.Conn, error) {
+	conn, err := net.Dial("tcp", upstreamAddr)
+	if err != nil {
+		return nil, fmt.Errorf("upstream dial failed (%s): %w", upstreamAddr, err)
+	}
+	if tlsConfig == nil {
+		return conn, nil
+	}
+
+	// PostgreSQL SSLRequest: 8 bytes total
+	// [4 bytes length = 8] [4 bytes code = 80877103 (0x04D2162F)]
+	var sslReq [8]byte
+	binary.BigEndian.PutUint32(sslReq[0:4], 8)
+	binary.BigEndian.PutUint32(sslReq[4:8], 80877103)
+	if _, err := conn.Write(sslReq[:]); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to send SSLRequest to upstream: %w", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	var resp [1]byte
+	if _, err := io.ReadFull(conn, resp[:]); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to read SSLRequest response from upstream: %w", err)
+	}
+	conn.SetReadDeadline(time.Time{})
+
+	switch resp[0] {
+	case 'S':
+		tlsConn := tls.Client(conn, tlsConfig)
+		if err := tlsConn.Handshake(); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("upstream TLS handshake failed: %w", err)
+		}
+		log.Printf("Upstream TLS negotiated via SSLRequest")
+		return tlsConn, nil
+	case 'N':
+		conn.Close()
+		log.Printf("Upstream rejected TLS (SSLRequest → N) — check RDS/server TLS config")
+		return nil, fmt.Errorf("upstream does not support TLS but UPSTREAM_TLS was set")
+	default:
+		conn.Close()
+		return nil, fmt.Errorf("unexpected SSLRequest response from upstream: 0x%02X", resp[0])
+	}
+}
+
 func runProxy(listenAddr, upstreamAddr string, pe *PolicyEngine, tlsCert, tlsKey string, upstreamTLS, upstreamTLSSkipVerify bool) {
 	var tlsConfig *tls.Config
 	if tlsCert != "" && tlsKey != "" {
@@ -115,13 +163,7 @@ func handleProxyConn(client net.Conn, upstreamAddr string, pe *PolicyEngine, tls
 				return
 			}
 		} else if proto == 80877102 { // CancelRequest
-			var upstream net.Conn
-			var dialErr error
-			if upstreamTLSConfig != nil {
-				upstream, dialErr = tls.Dial("tcp", upstreamAddr, upstreamTLSConfig)
-			} else {
-				upstream, dialErr = net.Dial("tcp", upstreamAddr)
-			}
+			upstream, dialErr := dialUpstream(upstreamAddr, upstreamTLSConfig)
 			if dialErr == nil {
 				upstream.Write(startupBuf)
 				upstream.Close()
@@ -163,15 +205,10 @@ func handleProxyConn(client net.Conn, upstreamAddr string, pe *PolicyEngine, tls
 		}
 	}
 
-	// 3. Connect to upstream Postgres (with optional TLS)
-	var upstream net.Conn
-	if upstreamTLSConfig != nil {
-		upstream, err = tls.Dial("tcp", upstreamAddr, upstreamTLSConfig)
-	} else {
-		upstream, err = net.Dial("tcp", upstreamAddr)
-	}
+	// 3. Connect to upstream Postgres (with optional TLS via SSLRequest)
+	upstream, err := dialUpstream(upstreamAddr, upstreamTLSConfig)
 	if err != nil {
-		log.Printf("Proxy: upstream dial failed (%s): %v", upstreamAddr, err)
+		log.Printf("Proxy: %v", err)
 		return
 	}
 	defer upstream.Close()

--- a/proxy_tls_test.go
+++ b/proxy_tls_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"io"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+func selfSignedTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{certDER},
+			PrivateKey:  key,
+		}},
+		MinVersion: tls.VersionTLS12,
+	}
+}
+
+// mockSSLServer simulates upstream Postgres SSLRequest negotiation.
+// response is the byte to reply after receiving SSLRequest ('S', 'N', or anything else).
+func mockSSLServer(t *testing.T, response byte, tlsConfig *tls.Config) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start mock server: %v", err)
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+
+				var buf [8]byte
+				if _, err := io.ReadFull(c, buf[:]); err != nil {
+					return
+				}
+				length := binary.BigEndian.Uint32(buf[0:4])
+				code := binary.BigEndian.Uint32(buf[4:8])
+				if length != 8 || code != 80877103 {
+					return
+				}
+
+				c.Write([]byte{response})
+
+				if response == 'S' && tlsConfig != nil {
+					tlsConn := tls.Server(c, tlsConfig)
+					if err := tlsConn.Handshake(); err != nil {
+						return
+					}
+					startupLen := make([]byte, 4)
+					io.ReadFull(tlsConn, startupLen)
+				}
+			}(conn)
+		}
+	}()
+
+	return ln
+}
+
+func mockPlainServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start mock server: %v", err)
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				lenBuf := make([]byte, 4)
+				if _, err := io.ReadFull(c, lenBuf); err != nil {
+					return
+				}
+				msgLen := int(binary.BigEndian.Uint32(lenBuf))
+				if msgLen > 4 {
+					discard := make([]byte, msgLen-4)
+					io.ReadFull(c, discard)
+				}
+			}(conn)
+		}
+	}()
+
+	return ln
+}
+
+func TestDialUpstream_SSLRequest_Accepted(t *testing.T) {
+	serverTLS := selfSignedTLSConfig(t)
+	ln := mockSSLServer(t, 'S', serverTLS)
+	defer ln.Close()
+
+	clientTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	conn, err := dialUpstream(ln.Addr().String(), clientTLS)
+	if err != nil {
+		t.Fatalf("dialUpstream failed: %v", err)
+	}
+	defer conn.Close()
+
+	if _, ok := conn.(*tls.Conn); !ok {
+		t.Fatal("expected *tls.Conn, got plain connection")
+	}
+}
+
+func TestDialUpstream_SSLRequest_Rejected(t *testing.T) {
+	ln := mockSSLServer(t, 'N', nil)
+	defer ln.Close()
+
+	clientTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	_, err := dialUpstream(ln.Addr().String(), clientTLS)
+	if err == nil {
+		t.Fatal("expected error when server rejects TLS, got nil")
+	}
+	if got := err.Error(); got != "upstream does not support TLS but UPSTREAM_TLS was set" {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}
+
+func TestDialUpstream_SSLRequest_UnexpectedByte(t *testing.T) {
+	ln := mockSSLServer(t, 'E', nil)
+	defer ln.Close()
+
+	clientTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	_, err := dialUpstream(ln.Addr().String(), clientTLS)
+	if err == nil {
+		t.Fatal("expected error for unexpected response byte, got nil")
+	}
+	expected := "unexpected SSLRequest response from upstream: 0x45"
+	if got := err.Error(); got != expected {
+		t.Fatalf("unexpected error: got %q, want %q", got, expected)
+	}
+}
+
+func TestDialUpstream_PlainConnection(t *testing.T) {
+	ln := mockPlainServer(t)
+	defer ln.Close()
+
+	conn, err := dialUpstream(ln.Addr().String(), nil)
+	if err != nil {
+		t.Fatalf("dialUpstream (plain) failed: %v", err)
+	}
+	defer conn.Close()
+
+	if _, ok := conn.(*tls.Conn); ok {
+		t.Fatal("expected plain net.Conn, got *tls.Conn")
+	}
+}
+
+func TestDialUpstream_SSLRequest_Timeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				var buf [8]byte
+				io.ReadFull(c, buf[:])
+				time.Sleep(10 * time.Second)
+			}(conn)
+		}
+	}()
+
+	clientTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	start := time.Now()
+	_, err = dialUpstream(ln.Addr().String(), clientTLS)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if elapsed > 7*time.Second {
+		t.Fatalf("dialUpstream took too long (%v) — deadline not working", elapsed)
+	}
+}
+
+func TestDialUpstream_SSLRequest_WireFormat(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	received := make(chan [8]byte, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var buf [8]byte
+		io.ReadFull(conn, buf[:])
+		received <- buf
+		conn.Write([]byte{'N'})
+	}()
+
+	clientTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	}
+	dialUpstream(ln.Addr().String(), clientTLS)
+
+	select {
+	case buf := <-received:
+		gotLen := binary.BigEndian.Uint32(buf[0:4])
+		gotCode := binary.BigEndian.Uint32(buf[4:8])
+		if gotLen != 8 {
+			t.Errorf("SSLRequest length: got %d, want 8", gotLen)
+		}
+		if gotCode != 80877103 {
+			t.Errorf("SSLRequest code: got %d, want 80877103", gotCode)
+		}
+		expectedBytes := [8]byte{0x00, 0x00, 0x00, 0x08, 0x04, 0xD2, 0x16, 0x2F}
+		if buf != expectedBytes {
+			t.Errorf("SSLRequest raw bytes: got %x, want %x", buf, expectedBytes)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for SSLRequest bytes")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes compatibility gap identified in `docs/compatibility.md` bug #1: FaultWall couldn't connect to any managed Postgres (RDS, Aurora, Cloud SQL, Supabase, Neon, CrunchyBridge) because the upstream TLS path used raw `tls.Dial` instead of Postgres's wire-protocol SSLRequest negotiation.

## The Bug

Before this PR, `proxy.go` called `tls.Dial("tcp", upstreamAddr, tlsConfig)` directly when `upstreamTLS=true`. PostgreSQL doesn't accept raw TLS on its protocol port — the client must first send an SSLRequest message and receive `'S'` from the server before upgrading to TLS. Against RDS this produced an EOF on the TLS handshake; disabling upstream TLS produced `no pg_hba.conf entry ... no encryption` because RDS refuses plaintext.

## The Fix

New helper `dialUpstream(addr, tlsConfig) (net.Conn, error)` in `proxy.go`:

1. `net.Dial("tcp", addr)` — always plain TCP first
2. If `tlsConfig == nil`, return the plain conn
3. Otherwise:
   - Write SSLRequest: `[len=8][code=80877103]` big-endian (`00 00 00 08 04 D2 16 2F`)
   - Read 1 byte with 5s deadline
   - `'S'` → wrap in `tls.Client(conn, tlsConfig)`, call `Handshake()`, log success
   - `'N'` → return error "upstream does not support TLS", log rejection
   - anything else → return error with hex dump of the unexpected byte

Both upstream dial call sites in `handleProxyConn` (CancelRequest path + main path) now use this helper.

## Tests

`proxy_tls_test.go` (new) — 6 tests using mock TCP servers (no external dependencies):

- `TestDialUpstream_SSLRequest_Accepted` — `'S'` response → returns `*tls.Conn`
- `TestDialUpstream_SSLRequest_Rejected` — `'N'` response → explicit error
- `TestDialUpstream_SSLRequest_UnexpectedByte` — `'E'` response → hex error
- `TestDialUpstream_PlainConnection` — nil tlsConfig → skips SSLRequest
- `TestDialUpstream_SSLRequest_Timeout` — non-responding server → 5s deadline
- `TestDialUpstream_SSLRequest_WireFormat` — asserts exact bytes `00 00 00 08 04 D2 16 2F`

All 6 pass locally. Pre-existing `TestUnidentifiedSafeQueryMonitored` failure is unrelated (reproducible on `main`).

## Manual validation

- Built binary connects cleanly to local Postgres (plain path, unchanged behavior)
- Will validate against RDS and Supabase in the follow-up compatibility re-run

## Scope

- **In scope:** upstream TLS handshake only
- **Out of scope:** the 4 other bugs in `docs/compatibility.md` — separate PRs
- No changes to `policy.go`, `parser.go`, CLI flags, or client-side TLS

## Follow-ups

Once merged, re-run the full compatibility matrix against: RDS, Aurora, Cloud SQL, Supabase (direct + pooler), Neon. Expect them all to flip 🔴 → 🟢.