### PR TITLE
fix(policy): unknown mission must not skip global blocklists (bug #3)

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -772,6 +772,16 @@ func (pe *PolicyEngine) CheckQuery(identity *AgentIdentity, query string, pid in
 	}
 
 	// Check mission policy
+	//
+	// Historical note (bug #3 from docs/compatibility.md, fixed Apr 27):
+	// this block previously did `return nil` when the agent carried a mission
+	// ID not present in their missions map AND default_policy != "deny".
+	// That short-circuited the global function blocklist check further down,
+	// letting any agent with an unknown mission bypass `blocked_functions`
+	// entirely (e.g. SELECT pg_sleep(9999) with PGAPPNAME=agent:x:mission:any:token:Y).
+	// Now we only run mission-scoped checks when a mission policy exists;
+	// absence of a policy under default-allow just skips mission checks
+	// and falls through to global checks (function blocklist, etc).
 	if identity.MissionID != "" {
 		missionPolicy, missionExists := agentPolicy.Missions[identity.MissionID]
 		if !missionExists {
@@ -787,33 +797,34 @@ func (pe *PolicyEngine) CheckQuery(identity *AgentIdentity, query string, pid in
 					Timestamp: time.Now(),
 				}
 			}
-			return nil
-		}
-
-		// Check tables against mission allowed list
-		if len(missionPolicy.Tables) > 0 {
-			for _, table := range tables {
-				if !isTableAllowed(table, missionPolicy.Tables) {
-					return &PolicyViolation{
-						AgentID:   identity.AgentID,
-						MissionID: identity.MissionID,
-						Query:     truncateQuery(query),
-						Reason:    "table_not_in_mission",
-						Table:     table,
-						Operation: operation,
-						PID:       pid,
-						Action:    "pending",
-						Timestamp: time.Now(),
+			// default_policy=allow: skip mission-scoped checks but CONTINUE
+			// through the rest of CheckQuery so global blocklists still apply.
+		} else {
+			// Check tables against mission allowed list
+			if len(missionPolicy.Tables) > 0 {
+				for _, table := range tables {
+					if !isTableAllowed(table, missionPolicy.Tables) {
+						return &PolicyViolation{
+							AgentID:   identity.AgentID,
+							MissionID: identity.MissionID,
+							Query:     truncateQuery(query),
+							Reason:    "table_not_in_mission",
+							Table:     table,
+							Operation: operation,
+							PID:       pid,
+							Action:    "pending",
+							Timestamp: time.Now(),
+						}
 					}
 				}
 			}
-		}
 
-		// Check mission conditions (for agents without profiles)
-		if agentPolicy.Profile == "" {
-			for _, op := range operations {
-				if v := checkConditions(missionPolicy.Conditions, op, query, identity, pid); v != nil {
-					return v
+			// Check mission conditions (for agents without profiles)
+			if agentPolicy.Profile == "" {
+				for _, op := range operations {
+					if v := checkConditions(missionPolicy.Conditions, op, query, identity, pid); v != nil {
+						return v
+					}
 				}
 			}
 		}

--- a/policy_mission_test.go
+++ b/policy_mission_test.go
@@ -1,0 +1,150 @@
+package main
+
+import "testing"
+
+// Regression tests for docs/compatibility.md bug #3:
+// When an agent carries a mission ID not in their missions map, and
+// default_policy is "allow", CheckQuery must NOT return nil early —
+// global checks (function blocklist, regproc cast, etc) must still run.
+//
+// Attack pattern reproduced in the Apr 27 compatibility audit across
+// local, RDS, and Neon:
+//   PGAPPNAME=agent:testagent:mission:attack:token:tok \
+//     psql -c "SELECT pg_sleep(9999)"
+// where testagent has profile=standard, auth_token=tok, but no "attack"
+// entry in their missions map. Before this fix, pg_sleep returned the
+// function result (bypass). After: pg_sleep is blocked by the global
+// BlockedFunctions check.
+
+func TestMissionEarlyReturn_GlobalBlocklistStillApplies(t *testing.T) {
+	pe := &PolicyEngine{
+		config: &PolicyConfig{
+			DefaultPolicy:    "allow",
+			BlockedFunctions: []string{"pg_sleep", "pg_read_file", "lo_export"},
+			Agents: map[string]AgentPolicy{
+				"testagent": {
+					AuthToken: "tok",
+					Profile:   "standard",
+					// Note: no "attack" mission defined — this is the bug repro
+					Missions: map[string]MissionPolicy{
+						"read": {Tables: []string{"public.feedback"}},
+					},
+				},
+			},
+			Unidentified: UnidentifiedPolicy{Policy: "allow"},
+		},
+		enforcement: "enforce",
+	}
+
+	// Agent sends a mission not in their map. Pre-fix: CheckQuery returned
+	// nil at the early-return, skipping the global BlockedFunctions check.
+	identity := &AgentIdentity{
+		AgentID:   "testagent",
+		MissionID: "attack",
+		Token:     "tok",
+	}
+
+	dangerous := []struct {
+		name  string
+		query string
+	}{
+		{"pg_sleep bypass", "SELECT pg_sleep(0.1)"},
+		{"pg_read_file bypass", "SELECT pg_read_file('/etc/passwd')"},
+		{"lo_export bypass", "SELECT lo_export(1234, '/tmp/pwn')"},
+	}
+	for _, tc := range dangerous {
+		t.Run(tc.name, func(t *testing.T) {
+			v := pe.CheckQuery(identity, tc.query, 0)
+			if v == nil {
+				t.Errorf("global blocked_function not applied for unknown-mission agent; query %q leaked", tc.query)
+			} else if v.Reason == "" || (v.Reason[:8] != "blocked_" && v.Reason != "unrecognized_operation") {
+				t.Errorf("unexpected violation reason for %q: %q", tc.query, v.Reason)
+			}
+		})
+	}
+}
+
+// When default_policy=deny, the old behavior (block the unknown mission)
+// must be preserved — this is a tightening fix, not a loosening fix.
+func TestMissionUnknown_DefaultDenyStillBlocks(t *testing.T) {
+	pe := &PolicyEngine{
+		config: &PolicyConfig{
+			DefaultPolicy: "deny",
+			Agents: map[string]AgentPolicy{
+				"testagent": {
+					AuthToken: "tok",
+					Missions: map[string]MissionPolicy{
+						"read": {Tables: []string{"public.feedback"}},
+					},
+				},
+			},
+			Unidentified: UnidentifiedPolicy{Policy: "allow"},
+		},
+		enforcement: "enforce",
+	}
+	identity := &AgentIdentity{AgentID: "testagent", MissionID: "attack", Token: "tok"}
+	v := pe.CheckQuery(identity, "SELECT 1", 0)
+	if v == nil {
+		t.Fatal("default_policy=deny must block unknown mission, got allow")
+	}
+	if v.Reason != "no_mission_policy" {
+		t.Errorf("expected reason=no_mission_policy, got %q", v.Reason)
+	}
+}
+
+// Known mission under default-allow: mission-scoped checks run normally.
+// Regression check for the refactored control flow.
+func TestMissionKnown_TableRestrictionStillApplies(t *testing.T) {
+	pe := &PolicyEngine{
+		config: &PolicyConfig{
+			DefaultPolicy: "allow",
+			Agents: map[string]AgentPolicy{
+				"testagent": {
+					AuthToken: "tok",
+					Missions: map[string]MissionPolicy{
+						"read": {Tables: []string{"public.feedback"}},
+					},
+				},
+			},
+			Unidentified: UnidentifiedPolicy{Policy: "allow"},
+		},
+		enforcement: "enforce",
+	}
+	identity := &AgentIdentity{AgentID: "testagent", MissionID: "read", Token: "tok"}
+
+	// Allowed table: passes
+	if v := pe.CheckQuery(identity, "SELECT * FROM public.feedback", 0); v != nil {
+		t.Errorf("allowed table should pass, got %+v", v)
+	}
+	// Disallowed table: mission-scoped block fires
+	v := pe.CheckQuery(identity, "SELECT * FROM public.secrets", 0)
+	if v == nil {
+		t.Fatal("non-mission table should be blocked")
+	}
+	if v.Reason != "table_not_in_mission" {
+		t.Errorf("expected reason=table_not_in_mission, got %q", v.Reason)
+	}
+}
+
+// Empty mission ID (agent without mission) under default-allow: everything
+// passes unless a global check triggers. Regression check for control flow.
+func TestNoMission_GlobalBlocklistStillApplies(t *testing.T) {
+	pe := &PolicyEngine{
+		config: &PolicyConfig{
+			DefaultPolicy:    "allow",
+			BlockedFunctions: []string{"pg_sleep"},
+			Agents: map[string]AgentPolicy{
+				"testagent": {AuthToken: "tok"},
+			},
+			Unidentified: UnidentifiedPolicy{Policy: "allow"},
+		},
+		enforcement: "enforce",
+	}
+	identity := &AgentIdentity{AgentID: "testagent", Token: "tok"}
+	if v := pe.CheckQuery(identity, "SELECT pg_sleep(0.1)", 0); v == nil {
+		t.Error("global blocked_function must apply to no-mission agent")
+	}
+	if v := pe.CheckQuery(identity, "SELECT 1", 0); v != nil {
+		t.Errorf("normal query must pass for no-mission agent, got %+v", v)
+	}
+}


### PR DESCRIPTION
## Summary

Closes bug #3 from `docs/compatibility.md`. The attack bypassed pg_sleep, pg_read_file, and lo_export on every tested platform (local, RDS, Neon) — same mechanism every time.

## The Attack

```bash
# testagent policy: profile=standard, auth_token=tok,
#                   missions={read: {...}}  # no 'attack' entry
PGAPPNAME='agent:testagent:mission:attack:token:tok' \\
  psql -c 'SELECT pg_sleep(9999)'
```

Expected: blocked (pg_sleep is in global `blocked_functions`).
Observed: pg_sleep executed.

## Root Cause

In `policy.go` CheckQuery, the mission-check block contained:

```go
if !missionExists {
    if cfg.DefaultPolicy == "deny" {
        return &PolicyViolation{Reason: "no_mission_policy", ...}
    }
    return nil  // ← BUG: skips everything after, including
                //   global BlockedFunctions at line 856
}
```

Under default-allow, unknown-mission = complete policy bypass.

## The Fix

Invert the control flow: when mission is unknown under default-allow, skip mission-scoped checks but `continue` past the mission block so the rest of CheckQuery runs (global function blocklist, regproc cast detection, etc). Wrapped the mission-scoped logic in an `else` branch of `if !missionExists` so the fall-through is explicit.

Under default-deny the old behavior is preserved — unknown mission returns `no_mission_policy` violation.

## Tests

`policy_mission_test.go` (new):
- `TestMissionEarlyReturn_GlobalBlocklistStillApplies` — reproduces the exact Apr 27 bypass, verifies pg_sleep/pg_read_file/lo_export are now blocked
- `TestMissionUnknown_DefaultDenyStillBlocks` — regression check on deny path
- `TestMissionKnown_TableRestrictionStillApplies` — mission-scoped `table_not_in_mission` still fires
- `TestNoMission_GlobalBlocklistStillApplies` — agent without any mission still hits global checks

All pass. Pre-existing unrelated failures (TestUnidentifiedSafeQueryMonitored, cmd/testparse) reproducible on main.

## Impact

After PR #8 (bug #2) and this PR (bug #3), the attack suite should drop from 4/10 bypasses → 0-1/10 on every platform. Bug #4 (regproc under mission states) was suspected to be a downstream effect of this one — expected to resolve automatically. I'll verify by re-running the attack suite once both merge.

## Scope

Touches `policy.go` CheckQuery mission block only. No changes to parser, proxy, CLI, or config. Behavior for known-mission agents and default-deny agents is unchanged.