### PR TITLE
fix(docker): copy assets/ into builder stage for go:embed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN go mod download
 # Copy source
 COPY *.go ./
 COPY templates/ ./templates/
+COPY assets/ ./assets/
 COPY policies.yaml ./
 
 # Build static binary with CGo (required for pg_query_go)


### PR DESCRIPTION
One-line fix. The Dockerfile builder stage didn't copy `assets/`, but `dashboard.go` has:

```go
//go:embed assets/logos/icon.png
```

Build failed with:
```
dashboard.go:18: pattern assets/logos/icon.png: no matching files found
```

Runtime stage already does `COPY assets/logos/` — this mirrors the same tree into the builder so `go build` has what `go:embed` needs.

Unblocks the Docker publish for v0.4.0. Orthogonal to the Intel Mac runner issue fixed in v0.3.1.

## Verification

- `go build` locally against the same embed tree succeeds (`/tmp/fw-dockerfix` built clean on this branch)
- Can't verify Docker build locally (colima won't start on this EC2 Mac), will rely on CI

## After merge

Either re-trigger the v0.4.0 Docker workflow or cut v0.4.1 with this fix so the image published matches the binary release.