### PR TITLE
feat(policy): column-level blocking per agent per table

### DIFF
--- a/blocked_columns_test.go
+++ b/blocked_columns_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// ── BlockedColumns (column-level denylist) ──────────────────────────────────
+//
+// Column-level enforcement: a policy may specify per-table column denylists.
+// A query that references a blocked column on a listed table is denied with
+// reason "blocked_column:<table>.<col>". Legitimate queries on the same table
+// that touch only allowed columns must pass through.
+
+func blockedColsEngine() *PolicyEngine {
+	return newTestEngine(&PolicyConfig{
+		DefaultPolicy: "deny",
+		Agents: map[string]AgentPolicy{
+			"support-agent": {
+				Profile: "standard",
+				Missions: map[string]MissionPolicy{
+					"respond-to-ticket": {
+						Tables: []string{"public.users", "public.feedback"},
+					},
+				},
+				BlockedColumns: map[string][]string{
+					"users": {"ssn", "password_hash", "api_key"},
+				},
+			},
+		},
+	})
+}
+
+func TestBlockedColumnsDirectSelect(t *testing.T) {
+	pe := blockedColsEngine()
+
+	// ssn is blocked — must deny
+	v := pe.CheckQuery(id("support-agent", "respond-to-ticket"),
+		"SELECT full_name, email, ssn FROM public.users LIMIT 5", 1)
+	if v == nil {
+		t.Fatal("expected violation for ssn column read, got nil")
+	}
+	if !strings.HasPrefix(v.Reason, "blocked_column:") {
+		t.Errorf("expected blocked_column reason, got %q", v.Reason)
+	}
+	if !strings.Contains(v.Reason, "ssn") {
+		t.Errorf("expected ssn in reason, got %q", v.Reason)
+	}
+}
+
+func TestBlockedColumnsAllowedColumnsPass(t *testing.T) {
+	pe := blockedColsEngine()
+
+	// Only name and email — must pass
+	v := pe.CheckQuery(id("support-agent", "respond-to-ticket"),
+		"SELECT full_name, email FROM public.users LIMIT 5", 1)
+	if v != nil {
+		t.Errorf("allowed columns should pass, got violation: %s", v.Reason)
+	}
+}
+
+func TestBlockedColumnsQualifiedReference(t *testing.T) {
+	pe := blockedColsEngine()
+
+	// users.ssn (qualified) — must deny
+	v := pe.CheckQuery(id("support-agent", "respond-to-ticket"),
+		"SELECT u.full_name, u.ssn FROM public.users u", 1)
+	if v == nil {
+		t.Fatal("expected violation for qualified ssn column read, got nil")
+	}
+	if !strings.HasPrefix(v.Reason, "blocked_column:") {
+		t.Errorf("expected blocked_column reason, got %q", v.Reason)
+	}
+}
+
+func TestBlockedColumnsPasswordHash(t *testing.T) {
+	pe := blockedColsEngine()
+
+	v := pe.CheckQuery(id("support-agent", "respond-to-ticket"),
+		"SELECT email, password_hash FROM public.users", 1)
+	if v == nil {
+		t.Fatal("expected violation for password_hash column read, got nil")
+	}
+	if !strings.Contains(v.Reason, "password_hash") {
+		t.Errorf("expected password_hash in reason, got %q", v.Reason)
+	}
+}
+
+func TestBlockedColumnsApiKey(t *testing.T) {
+	pe := blockedColsEngine()
+
+	v := pe.CheckQuery(id("support-agent", "respond-to-ticket"),
+		"SELECT email, api_key FROM public.users", 1)
+	if v == nil {
+		t.Fatal("expected violation for api_key column read, got nil")
+	}
+	if !strings.Contains(v.Reason, "api_key") {
+		t.Errorf("expected api_key in reason, got %q", v.Reason)
+	}
+}
+
+func TestBlockedColumnsInWhereClause(t *testing.T) {
+	pe := blockedColsEngine()
+
+	// ssn appears only in WHERE — still a column reference, still must deny.
+	// A support agent filtering by SSN is reading that column even if not in SELECT.
+	v := pe.CheckQuery(id("support-agent", "respond-to-ticket"),
+		"SELECT email FROM public.users WHERE ssn = '123-45-6789'", 1)
+	if v == nil {
+		t.Fatal("expected violation for ssn in WHERE, got nil")
+	}
+	if !strings.Contains(v.Reason, "ssn") {
+		t.Errorf("expected ssn in reason, got %q", v.Reason)
+	}
+}
+
+func TestBlockedColumnsStarDoesNotAutoBlock(t *testing.T) {
+	// SELECT * alone does not name columns — the column-block check does not
+	// fire on star by itself (parser records no column names for A_Star).
+	// The correct defense for SELECT * on a PII table is `blocked_tables`.
+	// This test documents that behavior so callers don't assume otherwise.
+	pe := newTestEngine(&PolicyConfig{
+		DefaultPolicy: "deny",
+		Agents: map[string]AgentPolicy{
+			"support-agent": {
+				Profile: "standard",
+				Missions: map[string]MissionPolicy{
+					"respond-to-ticket": {
+						Tables: []string{"public.users"},
+					},
+				},
+				BlockedColumns: map[string][]string{
+					"users": {"ssn"},
+				},
+			},
+		},
+	})
+
+	v := pe.CheckQuery(id("support-agent", "respond-to-ticket"),
+		"SELECT * FROM public.users", 1)
+	// No column-level violation expected; star expands server-side.
+	// Callers should pair BlockedColumns with BlockedTables or deny-star logic.
+	if v != nil && strings.HasPrefix(v.Reason, "blocked_column:") {
+		t.Errorf("SELECT * should not trigger column-level block directly, got %q", v.Reason)
+	}
+}
+
+func TestBlockedColumnsOtherTableNotAffected(t *testing.T) {
+	pe := blockedColsEngine()
+
+	// feedback table has no blocked columns — ssn-as-column-name is only
+	// blocked on the users table.
+	v := pe.CheckQuery(id("support-agent", "respond-to-ticket"),
+		"SELECT id, comment FROM public.feedback LIMIT 5", 1)
+	if v != nil {
+		t.Errorf("feedback query should pass, got violation: %s", v.Reason)
+	}
+}
+
+func TestBlockedColumnsUpdateSet(t *testing.T) {
+	// UPDATE ... SET ssn = 'x' must also be denied. The agent is writing
+	// to the blocked column, not just reading.
+	pe := newTestEngine(&PolicyConfig{
+		DefaultPolicy: "deny",
+		Agents: map[string]AgentPolicy{
+			"support-agent": {
+				Profile: "standard",
+				Missions: map[string]MissionPolicy{
+					"update-ticket": {
+						Tables: []string{"public.users: [UPDATE]"},
+					},
+				},
+				BlockedColumns: map[string][]string{
+					"users": {"ssn"},
+				},
+			},
+		},
+	})
+
+	v := pe.CheckQuery(id("support-agent", "update-ticket"),
+		"UPDATE public.users SET ssn = '999-99-9999' WHERE id = 1", 1)
+	if v == nil {
+		t.Fatal("expected violation for UPDATE SET ssn, got nil")
+	}
+}
+
+func TestBlockedColumnsConfigKeyWithSchema(t *testing.T) {
+	// blocked_columns key can be "public.users" or bare "users" — both must
+	// match when the query uses either form.
+	pe := newTestEngine(&PolicyConfig{
+		DefaultPolicy: "deny",
+		Agents: map[string]AgentPolicy{
+			"support-agent": {
+				Profile: "standard",
+				Missions: map[string]MissionPolicy{
+					"read": {
+						Tables: []string{"public.users"},
+					},
+				},
+				BlockedColumns: map[string][]string{
+					"public.users": {"ssn"},
+				},
+			},
+		},
+	})
+
+	v := pe.CheckQuery(id("support-agent", "read"),
+		"SELECT ssn FROM users", 1)
+	if v == nil {
+		t.Fatal("expected violation when config uses public.users and query uses users, got nil")
+	}
+	if !strings.Contains(v.Reason, "ssn") {
+		t.Errorf("expected ssn in reason, got %q", v.Reason)
+	}
+}

--- a/policy.go
+++ b/policy.go
@@ -78,6 +78,7 @@ type AgentPolicy struct {
 	Missions          map[string]MissionPolicy `yaml:"missions" json:"missions"`
 	BlockedOperations []string                 `yaml:"blocked_operations" json:"blocked_operations"`
 	BlockedTables     []string                 `yaml:"blocked_tables" json:"blocked_tables"`
+	BlockedColumns    map[string][]string      `yaml:"blocked_columns" json:"blocked_columns"` // table -> blocked column names (lowercase). Fires when the listed table is referenced AND any listed column appears in the query.
 	AllowedFunctions  []string                 `yaml:"allowed_functions" json:"allowed_functions"`
 }
 
@@ -771,6 +772,55 @@ func (pe *PolicyEngine) CheckQuery(identity *AgentIdentity, query string, pid in
 		}
 	}
 
+	// Check blocked columns (per-table column denylist).
+	//
+	// Policy semantics: if a query references a table T listed in blocked_columns
+	// AND any column name in parsed.Columns appears in blocked_columns[T], the
+	// query is denied with reason "blocked_column:<table>.<col>". This catches:
+	//
+	//   SELECT ssn FROM users          → denied
+	//   SELECT u.ssn FROM users u      → denied (parser extracts both "u" and "ssn")
+	//   SELECT email FROM users WHERE ssn = ?  → denied (WHERE-clause references)
+	//   UPDATE users SET ssn = ?       → denied (SET target)
+	//
+	// Behavior notes:
+	//   - SELECT * does NOT trigger a column-level block by itself; the parser
+	//     records no column names for the star target. Pair BlockedColumns with
+	//     BlockedTables when the entire table is off-limits.
+	//   - Multi-table queries that reference a blocked column name on any of the
+	//     listed tables deny the whole query (fail-closed). Schema resolution is
+	//     not performed — if an unqualified column name matches a blocklist
+	//     entry for a referenced table, the query is denied even if the column
+	//     actually originates from a different, un-listed table. This is the
+	//     conservative choice for a security product.
+	//   - Config keys may be unqualified ("users") or qualified ("public.users").
+	//     Matching is case-insensitive and handles either form on either side.
+	if len(agentPolicy.BlockedColumns) > 0 && len(parsed.Columns) > 0 {
+		for blockedTable, blockedCols := range agentPolicy.BlockedColumns {
+			if !isAnyTableReferenced(blockedTable, tables) {
+				continue
+			}
+			for _, bc := range blockedCols {
+				bcLower := strings.ToLower(bc)
+				for _, qc := range parsed.Columns {
+					if qc == bcLower {
+						return &PolicyViolation{
+							AgentID:   identity.AgentID,
+							MissionID: identity.MissionID,
+							Query:     truncateQuery(query),
+							Reason:    "blocked_column:" + blockedTable + "." + bcLower,
+							Table:     blockedTable,
+							Operation: operation,
+							PID:       pid,
+							Action:    "pending",
+							Timestamp: time.Now(),
+						}
+					}
+				}
+			}
+		}
+	}
+
 	// Check mission policy
 	//
 	// Historical note (bug #3 from docs/compatibility.md, fixed Apr 27):
@@ -1225,6 +1275,36 @@ func isTableBlocked(table string, blockedList []string) bool {
 			blockedLeaf = blockedLower[idx+1:]
 		}
 		if tableLeaf == blockedLeaf {
+			return true
+		}
+	}
+	return false
+}
+
+// isAnyTableReferenced reports whether the blocked_columns key `target` refers
+// to any of the tables extracted from the query. Matching is case-insensitive
+// and schema-agnostic: a config key of "users" matches a referenced
+// "public.users", and a key of "public.users" matches a referenced "users".
+// Used by the BlockedColumns enforcement in CheckQuery.
+func isAnyTableReferenced(target string, referenced []string) bool {
+	t := strings.ToLower(strings.TrimSpace(target))
+	if t == "" {
+		return false
+	}
+	tLeaf := t
+	if idx := strings.LastIndex(t, "."); idx >= 0 {
+		tLeaf = t[idx+1:]
+	}
+	for _, r := range referenced {
+		rLower := strings.ToLower(r)
+		if rLower == t {
+			return true
+		}
+		rLeaf := rLower
+		if idx := strings.LastIndex(rLower, "."); idx >= 0 {
+			rLeaf = rLower[idx+1:]
+		}
+		if tLeaf == rLeaf {
 			return true
 		}
 	}


### PR DESCRIPTION
Adds `BlockedColumns map[string][]string` to `AgentPolicy` \u2014 per-agent, per-table column denylists enforced at the SQL parser level.

## Config shape

```yaml
agents:
  support-agent:
    profile: standard
    blocked_columns:
      users:
        - ssn
        - password_hash
        - api_key
```

## Enforcement semantics

- Fires when a query references a listed table AND any listed column name appears in `parsed.Columns`
- Violation reason: `blocked_column:<table>.<col>`
- Config keys may be qualified (`public.users`) or unqualified (`users`); matching is case-insensitive and schema-agnostic in both directions
- Multi-table queries fail closed (no schema resolution at parse time)
- SELECT * does not trigger a column block by itself \u2014 pair with BlockedTables for full-table restrictions
- UPDATE ... SET blocked_col = ? is caught via the existing ResTarget extraction

## Demo use case

This is attack #2 in the 3-minute product video: customer-support agent with legit `users` read access tries to exfil `ssn` column via prompt injection. FaultWall blocks in <3ms.

## Tests

10 new tests in `blocked_columns_test.go`:
- Direct SELECT, qualified reference, WHERE-clause reference, UPDATE SET target
- password_hash, api_key, ssn individually
- Other-table isolation (ssn column name on a non-listed table is fine)
- SELECT * non-trigger behavior (documents the pair-with-BlockedTables pattern)
- Schema-normalized config keys (`public.users` key matches query `users`)

All 10 pass. Pre-existing `TestUnidentifiedSafeQueryMonitored` failure on main is unrelated.

## Shipping context

Built tonight as Option B of the demo-blocker decision \u2014 Shreyas records the YC founder video tomorrow and the column-level beat needed this feature. Ready to merge.