### PR TITLE
fix(dockerfile): don't hardcode GOARCH=amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ COPY *.go ./
 COPY templates/ ./templates/
 COPY policies.yaml ./
 
-# Build static binary with CGo (required for pg_query_go)
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+# Build static binary with CGo (required for pg_query_go).
+# Do NOT hardcode GOARCH — it breaks Apple Silicon builds. Go's default matches
+# the build host, and `docker buildx` sets TARGETARCH for cross-builds.
+ARG TARGETARCH
+RUN CGO_ENABLED=1 GOOS=linux go build \
     -ldflags="-w -s -linkmode external -extldflags '-static'" \
     -o faultwall .
 


### PR DESCRIPTION
Forcing `GOARCH=amd64` breaks CGo builds on Apple Silicon hosts (musl gcc has no amd64 target, errors out with `unrecognized command-line option '-m64'`). Go's default GOARCH matches the build host, and docker buildx sets TARGETARCH for explicit cross-builds, so remove the hardcode.

Reproduces as `docker compose up --build` failure on M1/M2/M3 Macs \u2014 most 2026 demo environments. Audit flagged 2026-05-03 before YC shoot.