### PR TITLE
fix(qwm): detect sensitive columns + retune cold-start weights

### DIFF
--- a/qwm_shadow.go
+++ b/qwm_shadow.go
@@ -38,12 +38,15 @@ type shadowQWMScorer struct {
 }
 
 // NewShadowQWMScorer returns a scorer initialised with conservative cold-start weights.
+// Weights are tuned so that destructive ops (DROP/TRUNCATE/DELETE/ALTER) and
+// PII-touching reads cross the default 0.7 flag threshold even before training,
+// while benign SELECT traffic stays comfortably below it.
 func NewShadowQWMScorer() *shadowQWMScorer {
 	return &shadowQWMScorer{
 		weights: [12]float64{
 			1.8,  // is_novel_fingerprint
-			0.9,  // op_type
-			1.4,  // touches_sensitive_table
+			1.6,  // op_type — raised so DROP/TRUNCATE/DELETE alone clears the flag threshold
+			1.6,  // touches_sensitive_table — now also fires on PII column references
 			0.5,  // n_joins
 			0.6,  // has_subquery
 			0.4,  // active_connections_norm
@@ -80,8 +83,12 @@ func (s *shadowQWMScorer) extract(pq *ParsedQuery, infra QWMInfraState) [12]floa
 	}
 	// 1: op_type normalised
 	fv[1] = qwmOpType(pq.Operation) / 3.0
-	// 2: touches_sensitive_table
-	if qwmSensitiveTables(pq.Tables) {
+	// 2: touches_sensitive_table OR sensitive column reference.
+	// Uses sensitiveQWMNames (a narrow secret-grade list: password, secret,
+	// token, api_key, ssn) rather than the broader pq.HasPII (which includes
+	// email/phone/address). Routine PII lookups by support agents shouldn't
+	// solo-flag; only secret-grade column refs should.
+	if qwmSensitiveTables(pq.Tables) || qwmSensitiveColumns(pq.Columns) {
 		fv[2] = 1
 	}
 	// 3: n_joins (not tracked in ParsedQuery yet — placeholder 0)
@@ -172,6 +179,22 @@ func qwmSensitiveTables(tables []string) bool {
 		tblL := strings.ToLower(tbl)
 		for _, pat := range sensitiveQWMNames {
 			if strings.Contains(tblL, pat) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// qwmSensitiveColumns mirrors qwmSensitiveTables for column references. Catches
+// SELECT password_hash FROM users — where the table name is benign but the
+// column reference itself signals secret access. Belt-and-braces with pq.HasPII
+// (set by the parser via piiColumnNames) so both signals contribute.
+func qwmSensitiveColumns(columns []string) bool {
+	for _, col := range columns {
+		colL := strings.ToLower(col)
+		for _, pat := range sensitiveQWMNames {
+			if strings.Contains(colL, pat) {
 				return true
 			}
 		}

--- a/qwm_shadow_test.go
+++ b/qwm_shadow_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestShadowQWMScorer_CrossesThresholdForDestructiveAndSensitive verifies the
+// cold-start weights flag the obvious bad cases without training. If this test
+// regresses, retune NewShadowQWMScorer weights or update the threshold.
+func TestShadowQWMScorer_CrossesThresholdForDestructiveAndSensitive(t *testing.T) {
+	scorer := NewShadowQWMScorer()
+	infra := QWMInfraState{}
+
+	cases := []struct {
+		name      string
+		query     string
+		shouldFlag bool
+	}{
+		{"benign-select-count", "SELECT count(*) FROM events WHERE event_name = 'login'", false},
+		{"benign-select-by-id", "SELECT id, email, name FROM users WHERE id = 42", false},
+		{"sensitive-column-pii", "SELECT id, password_hash FROM users LIMIT 5", true},
+		{"sensitive-column-via-join", "SELECT u.email, u.password_hash FROM users u JOIN events e ON e.user_id = u.id LIMIT 5", true},
+		{"drop-table", "DROP TABLE users", true},
+		{"truncate", "TRUNCATE events", true},
+		{"delete-no-where", "DELETE FROM events", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pq := ParseQuery(tc.query)
+			score := scorer.Score(pq, infra)
+			flagged := score > qwmFlagThreshold
+			if flagged != tc.shouldFlag {
+				t.Errorf("query=%q score=%.3f flagged=%v, want flagged=%v",
+					tc.query, score, flagged, tc.shouldFlag)
+			}
+		})
+	}
+}
+
+// TestQWMSensitiveColumns_DirectlyVerifyHelper guards the new column-aware path.
+func TestQWMSensitiveColumns_DirectlyVerifyHelper(t *testing.T) {
+	if !qwmSensitiveColumns([]string{"password_hash"}) {
+		t.Error("password_hash should be flagged as sensitive")
+	}
+	if !qwmSensitiveColumns([]string{"u.api_key"}) {
+		t.Error("api_key (qualified) should be flagged as sensitive")
+	}
+	if qwmSensitiveColumns([]string{"id", "email", "name"}) {
+		t.Error("plain non-sensitive columns should not be flagged")
+	}
+	if qwmSensitiveColumns(nil) {
+		t.Error("nil columns slice must not flag")
+	}
+}


### PR DESCRIPTION
## What

Two bugs in QWM shadow scoring exposed by E2E simulator on local PG.

### 1. Column-aware sensitivity detection
`qwmSensitiveTables()` only scanned table names. `SELECT password_hash FROM users` got the same score as `SELECT count(*)` because the table name (`users`) is benign. Added `qwmSensitiveColumns()` that walks `pq.Columns` against the same secret-grade name list (`password|secret|token|api_key|ssn`). Either signal now flips `fv[2]`.

### 2. Cold-start weight retune
Destructive ops (DROP/TRUNCATE/DELETE) scored **0.661** — just below the 0.7 flag threshold. Bumped:
- `op_type` 0.9 → 1.6
- `touches_sensitive_table` 1.4 → 1.6

Now destructive ops and secret-grade column reads each solo-cross threshold without training data, while benign reads stay comfortably below.

## Why not pq.HasPII?

The parser's `piiColumnNames` is intentionally broad — includes `email`, `phone`, `address`. Routine PII lookups by a support agent would solo-flag, drowning operators in false positives. QWM uses the narrower `sensitiveQWMNames` (secret-grade only); `pq.HasPII` stays as a separate signal for the policy engine.

## Test results

| Query | Before | After | Should flag? |
|---|---|---|---|
| `SELECT count(*) FROM events WHERE event_name='login'` | 0.442 | 0.442 | ❌ no |
| `SELECT id, email, name FROM users WHERE id = 42` | 0.797 (regression w/ HasPII) | 0.442 | ❌ no |
| `SELECT password_hash FROM users LIMIT 5` | 0.442 | >0.7 | ✅ yes |
| `DROP TABLE users` | 0.661 | >0.7 | ✅ yes |
| `TRUNCATE events` | 0.661 | >0.7 | ✅ yes |
| `DELETE FROM events` | 0.661 | >0.7 | ✅ yes |

Test added: `TestShadowQWMScorer_CrossesThresholdForDestructiveAndSensitive` + `TestQWMSensitiveColumns_DirectlyVerifyHelper`. All 7 subtests pass.

## How found

End-to-end simulator on local PG 16.13 (RFC-001 validation Phase 3) probed the shadow scorer directly. Both bugs caught before this hit any operator's monitor logs.

## Out of scope

- QWM training pipeline (eBPF labels → trained weights) — separate workstream, untouched.
- Policy engine PII handling — `pq.HasPII` semantics unchanged.