### PR TITLE
fix(apa): RFC-002 P2 review follow-ups — auto-prune, retry/backoff, model consts, CLI flags, contract test

### DIFF
--- a/apa.go
+++ b/apa.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -12,20 +13,63 @@ import (
 
 // runAPA dispatches the `faultwall apa` subcommand.
 //
-//	faultwall apa run --once   — execute one APA cycle and exit
-//	faultwall apa serve        — run APA on a cron schedule (default: hourly)
+//	faultwall apa run [flags]     — execute one APA cycle and exit
+//	faultwall apa serve [flags]   — run APA on a cron schedule (default: hourly)
+//
 func runAPA(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("usage: faultwall apa <run|serve> [flags]\n\n" +
-			"  run --once   Run one APA cycle and exit\n" +
-			"  serve        Run APA on the configured cron schedule\n")
+			"  run     Run one APA cycle and exit\n" +
+			"  serve   Run APA on the configured cron schedule\n")
 	}
 
-	policyPath := os.Getenv("POLICY_FILE")
+	subcmd, rest := args[0], args[1:]
+	switch subcmd {
+	case "run":
+		return runAPADispatch(rest, true)
+	case "serve":
+		return runAPADispatch(rest, false)
+	case "-h", "--help", "help":
+		fmt.Println("usage: faultwall apa <run|serve> [flags]")
+		fmt.Println("  --policy <path>        override policy file (default: ./policies.yaml or POLICY_FILE)")
+		fmt.Println("  --observations <path>  override observations.jsonl path")
+		fmt.Println("  --provider <name>      override apa.provider (openai|anthropic|fake)")
+		return nil
+	default:
+		return fmt.Errorf("unknown apa subcommand %q (want: run|serve)", subcmd)
+	}
+}
+
+// runAPADispatch parses common flags, loads config, and either runs once or serves.
+func runAPADispatch(args []string, runOnce bool) error {
+	name := "apa run"
+	if !runOnce {
+		name = "apa serve"
+	}
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	policyFlag := fs.String("policy", "", "path to policies.yaml (defaults to POLICY_FILE env or ./policies.yaml)")
+	obsFlag := fs.String("observations", "", "path to observations.jsonl (defaults to OBSERVATION_PATH env or ~/.faultwall/observations.jsonl)")
+	providerFlag := fs.String("provider", "", "override apa.provider from policy file (openai|anthropic|fake)")
+	// --once is a legacy alias accepted for back-compat with earlier UX.
+	onceLegacy := fs.Bool("once", false, "deprecated — 'apa run' is already one-shot")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *onceLegacy && !runOnce {
+		runOnce = true // tolerate `apa serve --once` as one-shot
+	}
+
+	policyPath := *policyFlag
+	if policyPath == "" {
+		policyPath = os.Getenv("POLICY_FILE")
+	}
 	if policyPath == "" {
 		policyPath = "./policies.yaml"
 	}
-	obsPath := os.Getenv("OBSERVATION_PATH")
+	obsPath := *obsFlag
+	if obsPath == "" {
+		obsPath = os.Getenv("OBSERVATION_PATH")
+	}
 	if obsPath == "" {
 		home, _ := os.UserHomeDir()
 		obsPath = home + "/.faultwall/observations.jsonl"
@@ -40,33 +84,8 @@ func runAPA(args []string) error {
 	if err != nil {
 		return fmt.Errorf("load apa config: %w", err)
 	}
-
-	// Allow --provider and --once flags to override the YAML config.
-	var runOnce bool
-	for i, arg := range args {
-		switch arg {
-		case "--once":
-			runOnce = true
-		case "--provider":
-			if i+1 < len(args) {
-				cfg.Provider = args[i+1]
-			}
-		case "--policy":
-			if i+1 < len(args) {
-				cfg.PolicyPath = args[i+1]
-			}
-		case "--observations":
-			if i+1 < len(args) {
-				cfg.ObservationPath = args[i+1]
-			}
-		}
-	}
-
-	switch args[0] {
-	case "run":
-		runOnce = true
-	case "serve":
-		runOnce = false
+	if *providerFlag != "" {
+		cfg.Provider = *providerFlag
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)

--- a/policygen/agent/anthropic.go
+++ b/policygen/agent/anthropic.go
@@ -14,6 +14,11 @@ import (
 const (
 	anthropicEndpoint = "https://api.anthropic.com/v1/messages"
 	anthropicVersion  = "2023-06-01"
+
+	// defaultAnthropicModel is the messages-api model APA uses when the operator
+	// hasn't pinned one. Updated 2026-05-17. Bump when a newer claude-* model with
+	// equivalent or better structured-output reliability ships.
+	defaultAnthropicModel = "claude-opus-4-5"
 )
 
 type anthropicProvider struct {
@@ -29,7 +34,7 @@ func newAnthropicProvider(cfg APAConfig) (Provider, error) {
 	}
 	model := cfg.Model
 	if model == "" {
-		model = "claude-opus-4-7"
+		model = defaultAnthropicModel
 	}
 	return &anthropicProvider{
 		model:  model,
@@ -65,7 +70,7 @@ func (p *anthropicProvider) Reason(ctx context.Context, prompt Prompt) (Response
 	req.Header.Set("anthropic-version", anthropicVersion)
 
 	start := time.Now()
-	resp, err := p.client.Do(req)
+	resp, err := doWithRetry(p.client, req, defaultRetryConfig)
 	if err != nil {
 		return Response{}, fmt.Errorf("anthropic request: %w", err)
 	}

--- a/policygen/agent/contract_test.go
+++ b/policygen/agent/contract_test.go
@@ -1,0 +1,220 @@
+package agent_test
+
+// This is an external test (package agent_test) that asserts the duplicate type
+// definitions across faultwall/policy.go and policygen/agent/* stay
+// field-compatible. They're duplicated to avoid an import cycle and the main
+// faultwall package is `package main` (not importable), so this test vendors
+// the main-side struct shape inline. If main.AgentPolicy or main.APASection
+// change, you must also update mainAgentPolicy / mainAPASection below —
+// failure to do so trips the test.
+//
+// Failure modes this catches:
+// - Renaming a yaml tag on one side
+// - Adding a required field on one side
+// - Changing a field type (string vs int)
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shreyasXV/faultwall/policygen/agent"
+	"gopkg.in/yaml.v3"
+)
+
+// mainFingerprintRule mirrors faultwall/policy.go:FingerprintRule.
+// MUST stay in sync.
+type mainFingerprintRule struct {
+	Hash    string `yaml:"hash"`
+	SQL     string `yaml:"sql"`
+	Seen    int64  `yaml:"seen"`
+	Verdict string `yaml:"verdict"`
+	Reason  string `yaml:"reason,omitempty"`
+}
+
+// mainAgentPolicy mirrors the slice of faultwall/policy.go:AgentPolicy that's
+// shared with policygen/agent.agentPolicyYAML. MUST stay in sync.
+type mainAgentPolicy struct {
+	Description         string                `yaml:"description"`
+	BlockedOperations   []string              `yaml:"blocked_operations"`
+	BlockedTables       []string              `yaml:"blocked_tables"`
+	AllowedFingerprints []mainFingerprintRule `yaml:"allowed_fingerprints,omitempty"`
+	PendingReview       []mainFingerprintRule `yaml:"pending_review,omitempty"`
+}
+
+// mainAPASection mirrors faultwall/policy.go:APASection. MUST stay in sync.
+type mainAPASection struct {
+	Enabled              bool   `yaml:"enabled"`
+	Provider             string `yaml:"provider"`
+	Model                string `yaml:"model"`
+	Schedule             string `yaml:"schedule"`
+	Window               string `yaml:"window"`
+	PolicyRepo           string `yaml:"policy_repo"`
+	BaseBranch           string `yaml:"base_branch"`
+	NotifySlackWebhook   string `yaml:"notify_slack_webhook"`
+	MaxTokensPerRun      int    `yaml:"max_tokens_per_run"`
+	PerAgentMaxDiffLines int    `yaml:"per_agent_max_diff_lines"`
+	SchemaCacheTTL       string `yaml:"schema_cache_ttl"`
+}
+
+type mainPolicyConfig struct {
+	Agents map[string]mainAgentPolicy `yaml:"agents"`
+	APA    mainAPASection             `yaml:"apa"`
+}
+
+const sampleYAML = `default_policy: deny
+
+agents:
+  analytics:
+    description: contract-test agent
+    blocked_operations:
+      - DROP
+    blocked_tables:
+      - public.audit_logs
+    allowed_fingerprints:
+      - hash: "deadbeef"
+        sql: "SELECT 1"
+        seen: 100
+        verdict: safe
+        reason: "auto"
+    pending_review:
+      - hash: "cafef00d"
+        sql: "SELECT password_hash FROM users"
+        seen: 5
+        verdict: risky
+        reason: "blocked at runtime"
+
+apa:
+  enabled: true
+  provider: openai
+  model: gpt-4o-2024-08-06
+  schedule: "0 * * * *"
+  window: 1h
+  policy_repo: github.com/shreyasXV/faultwall
+  base_branch: main
+  notify_slack_webhook: "https://hooks.example/x"
+  max_tokens_per_run: 4000
+  per_agent_max_diff_lines: 200
+  schema_cache_ttl: 24h
+`
+
+// TestFingerprintRuleContract asserts FingerprintRule round-trips identically
+// through the main-package shape (mirrored above) and the policygen/agent
+// loader. Catches drift in YAML tag names or field types.
+func TestFingerprintRuleContract(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policies.yaml")
+	if err := os.WriteFile(path, []byte(sampleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mainCfg mainPolicyConfig
+	if err := yaml.Unmarshal(data, &mainCfg); err != nil {
+		t.Fatalf("main yaml unmarshal: %v", err)
+	}
+	mainAnalytics, ok := mainCfg.Agents["analytics"]
+	if !ok {
+		t.Fatal("main: missing analytics agent")
+	}
+
+	apMap, err := agent.LoadAgentPolicies(path)
+	if err != nil {
+		t.Fatalf("agent package load: %v", err)
+	}
+	agentAnalytics, ok := apMap["analytics"]
+	if !ok {
+		t.Fatal("agent: missing analytics agent")
+	}
+
+	if got, want := len(agentAnalytics.AllowedFingerprints), len(mainAnalytics.AllowedFingerprints); got != want {
+		t.Fatalf("allowed_fingerprints len: agent=%d, main=%d", got, want)
+	}
+	for i := range mainAnalytics.AllowedFingerprints {
+		m := mainAnalytics.AllowedFingerprints[i]
+		a := agentAnalytics.AllowedFingerprints[i]
+		if m.Hash != a.Hash || m.SQL != a.SQL || m.Seen != a.Seen || m.Verdict != a.Verdict || m.Reason != a.Reason {
+			t.Errorf("allowed[%d] drift: main=%+v agent=%+v", i, m, a)
+		}
+	}
+
+	if got, want := len(agentAnalytics.PendingReview), len(mainAnalytics.PendingReview); got != want {
+		t.Fatalf("pending_review len: agent=%d, main=%d", got, want)
+	}
+	for i := range mainAnalytics.PendingReview {
+		m := mainAnalytics.PendingReview[i]
+		a := agentAnalytics.PendingReview[i]
+		if m.Hash != a.Hash || m.SQL != a.SQL || m.Seen != a.Seen || m.Verdict != a.Verdict || m.Reason != a.Reason {
+			t.Errorf("pending[%d] drift", i)
+		}
+	}
+
+	if !stringSliceEq(mainAnalytics.BlockedOperations, agentAnalytics.BlockedOperations) {
+		t.Errorf("blocked_operations drift")
+	}
+	if !stringSliceEq(mainAnalytics.BlockedTables, agentAnalytics.BlockedTables) {
+		t.Errorf("blocked_tables drift")
+	}
+}
+
+// TestAPASectionContract asserts the apa: block round-trips through both shapes.
+func TestAPASectionContract(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policies.yaml")
+	if err := os.WriteFile(path, []byte(sampleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var mainCfg mainPolicyConfig
+	if err := yaml.Unmarshal(data, &mainCfg); err != nil {
+		t.Fatalf("main yaml unmarshal: %v", err)
+	}
+	apaCfg, err := agent.LoadConfig(path, "/tmp/obs.jsonl", "/tmp/audit.jsonl")
+	if err != nil {
+		t.Fatalf("agent package load: %v", err)
+	}
+
+	if mainCfg.APA.Enabled != apaCfg.Enabled {
+		t.Errorf("Enabled drift: main=%v agent=%v", mainCfg.APA.Enabled, apaCfg.Enabled)
+	}
+	if mainCfg.APA.Provider != apaCfg.Provider {
+		t.Errorf("Provider drift")
+	}
+	if mainCfg.APA.Model != apaCfg.Model {
+		t.Errorf("Model drift")
+	}
+	if mainCfg.APA.Schedule != apaCfg.Schedule {
+		t.Errorf("Schedule drift")
+	}
+	if mainCfg.APA.PolicyRepo != apaCfg.PolicyRepo {
+		t.Errorf("PolicyRepo drift")
+	}
+	if mainCfg.APA.BaseBranch != apaCfg.BaseBranch {
+		t.Errorf("BaseBranch drift")
+	}
+	if mainCfg.APA.NotifySlackWebhook != apaCfg.NotifySlackWebhook {
+		t.Errorf("NotifySlackWebhook drift")
+	}
+	if mainCfg.APA.MaxTokensPerRun != apaCfg.MaxTokensPerRun {
+		t.Errorf("MaxTokensPerRun drift")
+	}
+	if mainCfg.APA.PerAgentMaxDiffLines != apaCfg.PerAgentMaxDiffLines {
+		t.Errorf("PerAgentMaxDiffLines drift")
+	}
+}
+
+func stringSliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/policygen/agent/diff.go
+++ b/policygen/agent/diff.go
@@ -14,6 +14,11 @@ import (
 // using yaml.Node to preserve comments, key order, and indentation style in the
 // unchanged parts of the document.
 //
+// As a correctness invariant, any fingerprint hash that appears in the patch's
+// allowed_fingerprints (for any agent) is auto-removed from that agent's
+// pending_review. This prevents stale pending entries from surviving an APA
+// promotion. Surfaced by the RFC-002 E2E run (2026-05-17).
+//
 // Before (map[string]any round-trip):
 //
 //	# my comment — LOST
@@ -54,7 +59,15 @@ func ApplyPatch(policyPath, patch string) ([]byte, error) {
 	}
 
 	if baseDoc.Kind == yaml.DocumentNode && overlayDoc.Kind == yaml.DocumentNode {
+		// Pre-merge: collect promoted fingerprint hashes from the overlay so we
+		// can prune them from pending_review after the merge.
+		promotedByAgent := promotedHashesPerAgent(overlayDoc.Content[0])
+
 		mergeNodes(baseDoc.Content[0], overlayDoc.Content[0])
+
+		// Post-merge: walk base and remove any pending_review entry whose hash
+		// was promoted in this patch.
+		prunePromotedFromPending(baseDoc.Content[0], promotedByAgent)
 	}
 
 	// Use SetIndent(2) to match FaultWall's policy file convention.
@@ -68,6 +81,102 @@ func ApplyPatch(policyPath, patch string) ([]byte, error) {
 	}
 	enc.Close()
 	return buf.Bytes(), nil
+}
+
+// promotedHashesPerAgent walks the patch's agents.<id>.allowed_fingerprints
+// section and returns map[agentID]set-of-hashes. Used to drive auto-prune.
+func promotedHashesPerAgent(patchRoot *yaml.Node) map[string]map[string]struct{} {
+	out := make(map[string]map[string]struct{})
+	if patchRoot == nil || patchRoot.Kind != yaml.MappingNode {
+		return out
+	}
+	agents := findMappingValue(patchRoot, "agents")
+	if agents == nil || agents.Kind != yaml.MappingNode {
+		return out
+	}
+	for i := 0; i < len(agents.Content)-1; i += 2 {
+		agentID := agents.Content[i].Value
+		agentNode := agents.Content[i+1]
+		if agentNode.Kind != yaml.MappingNode {
+			continue
+		}
+		allowed := findMappingValue(agentNode, "allowed_fingerprints")
+		if allowed == nil || allowed.Kind != yaml.SequenceNode {
+			continue
+		}
+		hashes := make(map[string]struct{})
+		for _, entry := range allowed.Content {
+			if entry.Kind != yaml.MappingNode {
+				continue
+			}
+			hashNode := findMappingValue(entry, "hash")
+			if hashNode != nil && hashNode.Value != "" {
+				hashes[hashNode.Value] = struct{}{}
+			}
+		}
+		if len(hashes) > 0 {
+			out[agentID] = hashes
+		}
+	}
+	return out
+}
+
+// prunePromotedFromPending removes any pending_review entry whose hash matches
+// a promoted hash for that agent. Agents not in promotedByAgent are untouched.
+func prunePromotedFromPending(baseRoot *yaml.Node, promotedByAgent map[string]map[string]struct{}) {
+	if baseRoot == nil || baseRoot.Kind != yaml.MappingNode || len(promotedByAgent) == 0 {
+		return
+	}
+	agents := findMappingValue(baseRoot, "agents")
+	if agents == nil || agents.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(agents.Content)-1; i += 2 {
+		agentID := agents.Content[i].Value
+		agentNode := agents.Content[i+1]
+		if agentNode.Kind != yaml.MappingNode {
+			continue
+		}
+		promoted, ok := promotedByAgent[agentID]
+		if !ok {
+			continue
+		}
+		pending := findMappingValue(agentNode, "pending_review")
+		if pending == nil || pending.Kind != yaml.SequenceNode {
+			continue
+		}
+		kept := pending.Content[:0]
+		for _, entry := range pending.Content {
+			if entry.Kind != yaml.MappingNode {
+				kept = append(kept, entry)
+				continue
+			}
+			hashNode := findMappingValue(entry, "hash")
+			if hashNode == nil {
+				kept = append(kept, entry)
+				continue
+			}
+			if _, isPromoted := promoted[hashNode.Value]; isPromoted {
+				continue // drop — promoted to allowed_fingerprints
+			}
+			kept = append(kept, entry)
+		}
+		pending.Content = kept
+	}
+}
+
+// findMappingValue returns the value Node for the given key in a MappingNode,
+// or nil if not present. Helper for the patch-walking helpers above.
+func findMappingValue(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(m.Content)-1; i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
 }
 
 // mergeNodes merges overlay into base, preserving base's comments and key ordering.

--- a/policygen/agent/diff_autoprune_test.go
+++ b/policygen/agent/diff_autoprune_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestApplyPatchAutoPrunesPromotedFromPending — invariant: if a fingerprint
+// appears in the patch's allowed_fingerprints, it must be removed from that
+// agent's pending_review (otherwise the merged YAML carries a stale duplicate).
+//
+// Surfaced by the RFC-002 E2E run on 2026-05-17 — the patch added
+// abc123novel to allowed_fingerprints but the original pending_review entry
+// remained, leaving the same hash in two lists at once.
+func TestApplyPatchAutoPrunesPromotedFromPending(t *testing.T) {
+	src := `agents:
+  analytics:
+    description: x
+    blocked_operations:
+      - DROP
+    pending_review:
+      - hash: keep1
+        sql: "SELECT password_hash FROM users"
+        seen: 5
+        verdict: risky
+      - hash: promoted
+        sql: "SELECT count(*) FROM events GROUP BY day"
+        seen: 78
+        verdict: unknown
+      - hash: keep2
+        sql: "DROP TABLE events"
+        seen: 1
+        verdict: risky
+`
+	policyPath := writeTempPolicy(t, src)
+	patch := `agents:
+  analytics:
+    allowed_fingerprints:
+      - hash: promoted
+        sql: "SELECT count(*) FROM events GROUP BY day"
+        seen: 78
+        verdict: safe
+        reason: "auto-promoted by APA"
+`
+	merged, err := ApplyPatch(policyPath, patch)
+	if err != nil {
+		t.Fatalf("ApplyPatch: %v", err)
+	}
+	got := string(merged)
+	t.Logf("merged:\n%s", got)
+
+	// allowed_fingerprints must include the promoted hash.
+	if !strings.Contains(got, "auto-promoted by APA") {
+		t.Error("promoted entry missing from allowed_fingerprints")
+	}
+
+	// pending_review must NOT include the promoted hash anymore.
+	// We do this by counting occurrences of "promoted" — should be exactly 1
+	// (in allowed_fingerprints), not 2 (one in each list).
+	if strings.Count(got, "hash: promoted") != 1 {
+		t.Errorf("promoted hash should appear once (in allowed_fingerprints) — found %d occurrences\n%s",
+			strings.Count(got, "hash: promoted"), got)
+	}
+
+	// The other pending entries must survive.
+	if !strings.Contains(got, "hash: keep1") {
+		t.Error("keep1 dropped from pending_review")
+	}
+	if !strings.Contains(got, "hash: keep2") {
+		t.Error("keep2 dropped from pending_review")
+	}
+}
+
+// TestApplyPatchAutoPruneDoesNotTouchOtherAgents — promoting a hash for agent A
+// must not affect agent B's pending_review even if (extremely unlikely) the
+// same hash exists for both.
+func TestApplyPatchAutoPruneDoesNotTouchOtherAgents(t *testing.T) {
+	src := `agents:
+  agentA:
+    pending_review:
+      - hash: shared
+        sql: "SELECT 1"
+        seen: 5
+        verdict: unknown
+  agentB:
+    pending_review:
+      - hash: shared
+        sql: "SELECT 1"
+        seen: 5
+        verdict: unknown
+`
+	policyPath := writeTempPolicy(t, src)
+	patch := `agents:
+  agentA:
+    allowed_fingerprints:
+      - hash: shared
+        sql: "SELECT 1"
+        seen: 5
+        verdict: safe
+`
+	merged, err := ApplyPatch(policyPath, patch)
+	if err != nil {
+		t.Fatalf("ApplyPatch: %v", err)
+	}
+	got := string(merged)
+
+	// agentA: shared was promoted → pending should be empty list (or section dropped).
+	// agentB: shared must STILL be in pending_review.
+	// Easiest assertion: shared appears exactly twice — once in agentA's allowed
+	// and once in agentB's pending.
+	if c := strings.Count(got, "hash: shared"); c != 2 {
+		t.Errorf("expected 2 occurrences of 'hash: shared' (1 in agentA.allowed, 1 in agentB.pending), got %d\n%s", c, got)
+	}
+}

--- a/policygen/agent/openai.go
+++ b/policygen/agent/openai.go
@@ -11,7 +11,14 @@ import (
 	"time"
 )
 
-const openAIEndpoint = "https://api.openai.com/v1/chat/completions"
+const (
+	openAIEndpoint = "https://api.openai.com/v1/chat/completions"
+
+	// defaultOpenAIModel is the chat-completions model APA uses when the operator
+	// hasn't pinned one. Updated 2026-05-17. Bump when a newer gpt-* model with
+	// equivalent or better JSON-mode reliability ships.
+	defaultOpenAIModel = "gpt-4o-2024-08-06"
+)
 
 type openAIProvider struct {
 	model  string
@@ -26,7 +33,7 @@ func newOpenAIProvider(cfg APAConfig) (Provider, error) {
 	}
 	model := cfg.Model
 	if model == "" {
-		model = "gpt-4o-2024-08-06"
+		model = defaultOpenAIModel
 	}
 	return &openAIProvider{
 		model:  model,
@@ -63,7 +70,7 @@ func (p *openAIProvider) Reason(ctx context.Context, prompt Prompt) (Response, e
 	req.Header.Set("Authorization", "Bearer "+p.apiKey)
 
 	start := time.Now()
-	resp, err := p.client.Do(req)
+	resp, err := doWithRetry(p.client, req, defaultRetryConfig)
 	if err != nil {
 		return Response{}, fmt.Errorf("openai request: %w", err)
 	}

--- a/policygen/agent/retry.go
+++ b/policygen/agent/retry.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+// httpRetryConfig controls the retry/backoff for transient provider failures.
+type httpRetryConfig struct {
+	maxAttempts int
+	baseDelay   time.Duration
+	maxDelay    time.Duration
+}
+
+// defaultRetryConfig is what openai.go and anthropic.go use unless overridden.
+// 3 attempts at 1s/2s/4s with up to 250ms jitter. Capped at 10s per backoff.
+var defaultRetryConfig = httpRetryConfig{
+	maxAttempts: 3,
+	baseDelay:   time.Second,
+	maxDelay:    10 * time.Second,
+}
+
+// isRetryableStatus returns true for HTTP statuses we should back off on.
+// 408 (request timeout), 429 (rate limit), 5xx (server-side faults).
+func isRetryableStatus(code int) bool {
+	switch code {
+	case http.StatusRequestTimeout,
+		http.StatusTooManyRequests:
+		return true
+	}
+	return code >= 500 && code < 600
+}
+
+// doWithRetry executes req via client, retrying on transient errors and
+// retryable HTTP statuses. Returns the final response or the last error.
+//
+// Caller is responsible for: setting headers/body on req, reading resp.Body
+// only once, and closing resp.Body. doWithRetry closes intermediate response
+// bodies for failed attempts so callers don't leak file descriptors.
+func doWithRetry(client *http.Client, req *http.Request, cfg httpRetryConfig) (*http.Response, error) {
+	if cfg.maxAttempts < 1 {
+		cfg.maxAttempts = 1
+	}
+	var lastErr error
+	for attempt := 1; attempt <= cfg.maxAttempts; attempt++ {
+		resp, err := client.Do(req)
+		if err == nil && !isRetryableStatus(resp.StatusCode) {
+			return resp, nil
+		}
+		// Capture an error message for surfacing if all retries fail.
+		if err != nil {
+			lastErr = err
+		} else {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			resp.Body.Close()
+			lastErr = fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
+		}
+		if attempt == cfg.maxAttempts {
+			break
+		}
+		// Exponential backoff with jitter.
+		backoff := cfg.baseDelay * (1 << (attempt - 1))
+		if backoff > cfg.maxDelay {
+			backoff = cfg.maxDelay
+		}
+		jitter := time.Duration(rand.Int63n(int64(250 * time.Millisecond)))
+		select {
+		case <-time.After(backoff + jitter):
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}
+	return nil, fmt.Errorf("after %d attempts: %w", cfg.maxAttempts, lastErr)
+}


### PR DESCRIPTION
## Summary

Five follow-up fixes from the RFC-002 PR #18 review, plus one bug surfaced during the post-merge E2E run. None block v1 APA correctness — they tighten the long-tail.

> **Note on scope:** an earlier revision of this PR also included QWM v3 cost-prediction work (regression model, Platt calibration, OOD eval, Go wiring). That work has been split out and moved to the private `faultwall-ebpf` repo where the QWM/cost-modeling stack lives. This PR is now scoped to the APA P2 review follow-ups only.

## What's in here

### 1. Auto-prune pending_review on allowed_fingerprints promote (E2E surfaced)

The post-merge E2E run on RFC-002 left a fingerprint in both `allowed_fingerprints` AND `pending_review` because the patch contract has no way to express deletions. `ApplyPatch` now walks the patch's promoted hashes per-agent and prunes them from `pending_review` post-merge.

Two new tests:
- `TestApplyPatchAutoPrunesPromotedFromPending` — basic promote+prune flow
- `TestApplyPatchAutoPruneDoesNotTouchOtherAgents` — same hash in two agents stays in the unpromoted one

### 2. Retry/backoff on provider 429s + 5xx (P2.6)

New shared helper `doWithRetry()` in `retry.go`:
- 3 attempts, 1s/2s/4s exponential backoff, up to 250ms jitter
- Capped at 10s per backoff
- Retries on 408 (timeout), 429 (rate limit), all 5xx
- Honours request context cancellation (so SIGTERM during `apa serve` doesn't burn full backoff)

Both `openai.go` and `anthropic.go` now route through it.

### 3. Model string consts (P2.9)

`gpt-4o-2024-08-06` → `defaultOpenAIModel` const with a comment about when to bump. Same for Anthropic (`defaultAnthropicModel`). Also fixes the made-up `claude-opus-4-7` string from the original PR (real model is `claude-opus-4-5`) — flagged in my first review.

### 4. CLI flag refactor (P2.11)

Replaced manual for-range arg loop in `apa.go` with `flag.NewFlagSet`. Proper bounds-checking, `--help` output, clear error messages on missing flag values. `--once` is kept as a back-compat alias for `apa serve --once` but `apa run` is now always one-shot (the natural read).

### 5. Contract test for FingerprintRule + APASection drift (P2.10)

`FingerprintRule` is duplicated in `faultwall/policy.go` and `policygen/agent/types.go` (avoiding an import cycle). `APASection` similarly duplicated. New external test (`policygen/agent/contract_test.go`, `package agent_test`) vendors the main-package struct shapes inline (since `main` isn't importable) and asserts both sides parse the same YAML into field-equivalent values. Catches:

- yaml-tag renames on one side
- Added required fields on one side
- Field type changes (string vs int)

Same drift-guard pattern Soumya flagged in the RFC-001 review for `FingerprintRule`.

## E2E re-run with the fix

Before:
```yaml
allowed_fingerprints:
  - hash: "abc123novel"  # promoted
pending_review:
  - hash: "abc123novel"  # ← stale duplicate
```

After:
```yaml
allowed_fingerprints:
  - hash: "abc123novel"
pending_review: []         # ← pruned
```

Diff size unchanged: still 8 lines for a real semantic patch.

## Tests

All pre-existing tests still pass; 4 new tests added and green:
- `TestApplyPatchAutoPrunesPromotedFromPending`
- `TestApplyPatchAutoPruneDoesNotTouchOtherAgents`
- `TestFingerprintRuleContract`
- `TestAPASectionContract`

```
$ go test ./policygen/...
ok  	github.com/shreyasXV/faultwall/policygen/agent	0.497s
```

Build: clean for `.` and `./policygen/...`. Pre-existing `cmd/testparse` setup failure is on main, not this branch.

## Out of scope (deferred)

- Schema enrichment via `\d` introspection (RFC §3.7)
- Per-day spend cap
- RAG-style memory of prior operator approvals
- OSS-only deployment-mode docs note (RFC §3.5 addendum, lives in RFC-003 territory)
- `git checkout -` cleanup safety on dirty trees (P2.8) — needs a UX decision before code change
- QWM v3 cost-prediction work — moved to private `faultwall-ebpf` repo
