### PR TITLE
qwm: RFC-003 state-conditioned world model

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 	policyEngine     *PolicyEngine
 	observationStore   *ObservationStore
 	qwmScorer          QWMScorer
+	qwmStateSampler    *StateSampler
 	qwmFlagThreshold   = 0.7 // shadow mode: flag but never block
 )
 
@@ -130,7 +131,35 @@ func main() {
 		policyEngine = NewPolicyEngine()
 		agentTracker = NewAgentTracker()
 		observationStore = NewObservationStore(os.Getenv("OBSERVATION_PATH"))
-		qwmScorer = NewShadowQWMScorer()
+
+		// QWM: RFC-003 state-conditioned world model. Loads an optional trained
+		// artifact (FW_QWM_MODEL or ~/.faultwall/qwm_world_model.json); otherwise
+		// uses cold-start defaults. Falls back to the shape-based shadow scorer for
+		// fingerprints with no learned base service, so we never regress.
+		shapeFallback := NewShadowQWMScorer()
+		wmArtifact := loadWorldModelArtifact()
+		qwmScorer = NewWorldModelScorer(wmArtifact, shapeFallback)
+
+		// Live DB-state sampler (~1s) feeding the world model. Uses DATABASE_URL
+		// or a monitoring DSN derived from the upstream; degrades to queuing-prior
+		// only if no monitoring connection is available.
+		if dsn, ok := monitoringDSNFromUpstream(proxyUpstream); ok {
+			if mdb, err := openMonitoringDB(dsn); err == nil {
+				if perr := mdb.Ping(); perr == nil {
+					cores := qwmConfiguredCores()
+					qwmStateSampler = NewStateSampler(mdb, cores, time.Second)
+					qwmStateSampler.Start()
+					log.Printf("⚡ QWM world model active (SLO %.0fms, %.0f core(s)) — live state sampling on", wmArtifact.SLOms, cores)
+				} else {
+					mdb.Close()
+					log.Printf("⚡ QWM world model active (queuing prior only) — monitoring DB ping failed: %v", perr)
+				}
+			} else {
+				log.Printf("⚡ QWM world model active (queuing prior only) — monitoring DB open failed: %v", err)
+			}
+		} else {
+			log.Printf("⚡ QWM world model active (queuing prior only) — no monitoring DSN")
+		}
 		go func() {
 			ticker := time.NewTicker(60 * time.Second)
 			defer ticker.Stop()

--- a/proxy.go
+++ b/proxy.go
@@ -390,6 +390,12 @@ func proxyQueryLoop(client, upstream net.Conn, identity *AgentIdentity, agentLab
 	// Per-query stats tracking
 	var queryStartTime time.Time
 	queryRowCount := 0
+	// inFlightFingerprint carries the fingerprint of the currently-executing
+	// query from the request goroutine to the response goroutine so the QWM world
+	// model can record the query's measured latency against its fingerprint when
+	// ReadyForQuery ('Z') arrives. Same shared-closure pattern as queryStartTime.
+	var inFlightFingerprint string
+	var inFlightUnderLoad float64
 
 	// Goroutine: relay upstream responses → client with DataRow counting
 	go func() {
@@ -436,6 +442,13 @@ func proxyQueryLoop(client, upstream net.Conn, identity *AgentIdentity, agentLab
 					agentTracker.RecordRows(identity.AgentID, int64(queryRowCount))
 					agentTracker.RecordDuration(identity.AgentID, durationMs)
 				}
+				// RFC-003: feed the measured latency to the QWM world model's
+				// per-fingerprint base-service EWMA (only learns under low load).
+				if !queryStartTime.IsZero() && inFlightFingerprint != "" {
+					durationMs := float64(time.Since(queryStartTime).Microseconds()) / 1000.0
+					recordQueryLatency(inFlightFingerprint, durationMs, inFlightUnderLoad)
+				}
+				inFlightFingerprint = ""
 				queryRowCount = 0
 				queryStartTime = time.Time{}
 
@@ -499,6 +512,12 @@ func proxyQueryLoop(client, upstream net.Conn, identity *AgentIdentity, agentLab
 			} else {
 				logAllowed(agentLabel, query)
 				scoreQueryShadow(agentLabel, query, pq)
+				// RFC-003: remember this fingerprint + the load it ran under so the
+				// response goroutine can record its latency into the base-service EWMA.
+				if pq != nil {
+					inFlightFingerprint = pq.Fingerprint
+					inFlightUnderLoad = currentUtilization()
+				}
 				emitTelemetryFor("allowed", "allow", nil, pq, decisionLatencyMs)
 			}
 			recordObservation(agentLabel, identity, query, pq, false)
@@ -871,26 +890,57 @@ func logMonitored(agent, query string, v *PolicyViolation) {
 
 // scoreQueryShadow runs the QWM scorer in shadow mode (observe-only, never blocks).
 // pq is the already-parsed query from safeCheckQuery — no second CGO call.
+//
+// RFC-003: infra is now the LIVE DB-state snapshot from the StateSampler (not the
+// old QWMInfraState{} stub), so the world-model scorer is state-conditioned.
 func scoreQueryShadow(agentLabel, query string, pq *ParsedQuery) {
 	if qwmScorer == nil || pq == nil {
 		return
 	}
-	infra := QWMInfraState{} // TODO: populate from collector once integrated
+	infra := currentInfraState()
 	score := qwmScorer.Score(pq, infra)
 	if score > qwmFlagThreshold {
 		top := qwmScorer.TopFeatures(pq, infra, 3)
 		logQWMFlag(agentLabel, query, score, top)
-		// F11: persist the flag so the dashboard can show it (observe-only;
-		// this does not affect the allow/block decision).
-		recordQWMFlag(QWMFlagRecord{
+
+		// RFC-003: enrich the flag with world-model predictions when available.
+		rec := QWMFlagRecord{
 			Agent:       agentLabel,
 			Query:       querySnippet(query),
 			Score:       score,
 			TopFeatures: top,
 			Operation:   pq.Operation,
 			Tables:      pq.Tables,
+			Utilization: infra.Utilization,
 			Timestamp:   time.Now(),
-		})
+		}
+		if wm, ok := qwmScorer.(*worldModelScorer); ok {
+			if predicted, pBreach, used := wm.Predict(pq, infra); used {
+				rec.PredictedMs = predicted
+				rec.PBreach = pBreach
+			}
+		}
+		recordQWMFlag(rec)
+	}
+}
+
+// currentInfraState returns the live DB-state snapshot for the world model, or a
+// zero state (→ queuing-prior/fallback path) when no sampler is running.
+func currentInfraState() QWMInfraState {
+	if qwmStateSampler != nil {
+		return qwmStateSampler.Snapshot()
+	}
+	return QWMInfraState{}
+}
+
+// currentUtilization is a hot-path-cheap read of the cached utilization.
+func currentUtilization() float64 { return currentInfraState().Utilization }
+
+// recordQueryLatency feeds a measured query latency into the world model's
+// per-fingerprint base-service EWMA. No-op unless the world-model scorer is active.
+func recordQueryLatency(fingerprint string, latencyMs, utilization float64) {
+	if wm, ok := qwmScorer.(*worldModelScorer); ok {
+		wm.Observe(fingerprint, latencyMs, utilization)
 	}
 }
 

--- a/qwm_shadow.go
+++ b/qwm_shadow.go
@@ -26,6 +26,17 @@ type QWMInfraState struct {
 	BaselineQueryTimeMs float64
 	LockContentionMs    float64
 	AnomalyRateAgent    float64
+
+	// ── RFC-003 world-model state (live DB state s_t) ──
+	// Populated by the StateSampler goroutine (qwm_state.go) from
+	// pg_stat_activity, refreshed ~1s. Zero values mean "unknown" → the world
+	// model falls back to its queuing prior / cold-start path.
+	ActiveBackends  int     // non-idle backends running queries
+	BlockedBackends int     // backends waiting on a lock
+	LongestActiveMs float64 // age of the longest-running active query
+	CacheHitRatio   float64 // shared-buffer cache hit ratio [0,1]
+	TPS             float64 // transactions/sec (xact_commit+rollback delta)
+	Utilization     float64 // ρ proxy: max(active_backends, cpu)/cores, [0,~)
 }
 
 // shadowQWMScorer is the built-in logistic regression scorer used in shadow mode.
@@ -238,6 +249,12 @@ type QWMFlagRecord struct {
 	Operation   string    `json:"operation"`
 	Tables      []string  `json:"tables,omitempty"`
 	Timestamp   time.Time `json:"timestamp"`
+
+	// RFC-003 world-model fields (zero when the world model has no base for the
+	// fingerprint yet — i.e. the shape-based fallback produced the score).
+	PredictedMs float64 `json:"predicted_ms,omitempty"`
+	PBreach     float64 `json:"p_breach,omitempty"`
+	Utilization float64 `json:"utilization,omitempty"`
 }
 
 const qwmFlagRingSize = 500

--- a/qwm_state.go
+++ b/qwm_state.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ── RFC-003 §4.1A: live DB-state sampler ──
+//
+// StateSampler polls pg_stat_activity on a short interval (~1s) in a background
+// goroutine and caches a QWMInfraState snapshot. The query hot path reads the
+// cached snapshot with an atomic load — it NEVER queries the DB inline, so the
+// hot-path cost is a pointer load (RFC §7 / acceptance: <0.2ms/query in shadow).
+//
+// Utilization (ρ) is a FAST signal: active backends / configured cores. We avoid
+// loadavg deliberately — its 1-min smoothing lags real load by ~a minute and
+// produces stale rejections (one of the two hard lessons in the RFC).
+
+// StateSampler owns the monitoring connection and the cached snapshot.
+type StateSampler struct {
+	db       *sql.DB
+	cores    float64
+	interval time.Duration
+
+	snap atomic.Value // holds QWMInfraState
+
+	stopOnce sync.Once
+	stop     chan struct{}
+
+	// for TPS delta computation between samples
+	lastXact   int64
+	lastSample time.Time
+}
+
+// NewStateSampler builds a sampler. cores is the configured core count used as
+// the utilization denominator; if <=0 it defaults to 1 (single-core assumption,
+// conservative — utilization reads higher, so we err toward caution).
+func NewStateSampler(db *sql.DB, cores float64, interval time.Duration) *StateSampler {
+	if cores <= 0 {
+		cores = 1
+	}
+	if interval <= 0 {
+		interval = time.Second
+	}
+	s := &StateSampler{db: db, cores: cores, interval: interval, stop: make(chan struct{})}
+	s.snap.Store(QWMInfraState{}) // zero = unknown until first sample
+	return s
+}
+
+// Snapshot returns the most recent cached state. Hot-path safe (atomic load).
+func (s *StateSampler) Snapshot() QWMInfraState {
+	if v, ok := s.snap.Load().(QWMInfraState); ok {
+		return v
+	}
+	return QWMInfraState{}
+}
+
+// Start launches the sampling goroutine. Safe to call once.
+func (s *StateSampler) Start() {
+	if s.db == nil {
+		log.Printf("⚠️  QWM state sampler: no monitoring DB — world model runs on queuing prior only")
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(s.interval)
+		defer ticker.Stop()
+		// Prime once immediately so the first queries get real state quickly.
+		s.sampleOnce()
+		for {
+			select {
+			case <-s.stop:
+				return
+			case <-ticker.C:
+				s.sampleOnce()
+			}
+		}
+	}()
+}
+
+// Stop ends the sampling goroutine.
+func (s *StateSampler) Stop() {
+	s.stopOnce.Do(func() { close(s.stop) })
+}
+
+// sampleOnce reads pg_stat_activity + a couple of cheap stat views and updates
+// the cached snapshot. Errors are logged at low volume and leave the previous
+// snapshot in place (graceful degradation).
+func (s *StateSampler) sampleOnce() {
+	var (
+		active   int
+		blocked  int
+		longest  float64
+		cacheHit float64
+		xact     int64
+	)
+
+	// active + blocked backends and the longest active query age, in one pass.
+	// Note: FILTER attaches to aggregates only, so min(query_start) is filtered
+	// (valid) and the EXTRACT/now() math is applied to the aggregate result.
+	row := s.db.QueryRow(`
+		SELECT
+		  count(*) FILTER (WHERE state = 'active') AS active,
+		  count(*) FILTER (WHERE wait_event_type = 'Lock') AS blocked,
+		  COALESCE(EXTRACT(EPOCH FROM (now() - min(query_start) FILTER (WHERE state = 'active'))), 0) * 1000 AS longest_ms
+		FROM pg_stat_activity
+		WHERE pid <> pg_backend_pid()`)
+	if err := row.Scan(&active, &blocked, &longest); err != nil {
+		s.logSampleErr("activity", err)
+		return
+	}
+
+	// cache hit ratio (cheap, db-wide).
+	_ = s.db.QueryRow(`
+		SELECT CASE WHEN blks_hit + blks_read = 0 THEN 1.0
+		            ELSE blks_hit::float8 / (blks_hit + blks_read) END
+		FROM pg_stat_database WHERE datname = current_database()`).Scan(&cacheHit)
+
+	// transactions for TPS delta.
+	_ = s.db.QueryRow(`
+		SELECT COALESCE(sum(xact_commit + xact_rollback), 0)
+		FROM pg_stat_database WHERE datname = current_database()`).Scan(&xact)
+
+	now := time.Now()
+	var tps float64
+	if !s.lastSample.IsZero() && xact >= s.lastXact {
+		dt := now.Sub(s.lastSample).Seconds()
+		if dt > 0 {
+			tps = float64(xact-s.lastXact) / dt
+		}
+	}
+	s.lastXact = xact
+	s.lastSample = now
+
+	util := float64(active) / s.cores
+
+	s.snap.Store(QWMInfraState{
+		ActiveBackends:  active,
+		BlockedBackends: blocked,
+		LongestActiveMs: longest,
+		CacheHitRatio:   cacheHit,
+		TPS:             tps,
+		Utilization:     util,
+		// keep the legacy fields populated too for the shape scorer
+		ActiveConnections: active,
+	})
+}
+
+var stateSampleErrCount int64
+
+func (s *StateSampler) logSampleErr(which string, err error) {
+	// Log the first error and then every 60th to avoid spam if the monitoring
+	// connection is down (proxy keeps serving on the queuing prior meanwhile).
+	n := atomic.AddInt64(&stateSampleErrCount, 1)
+	if n == 1 || n%60 == 0 {
+		log.Printf("⚠️  QWM state sample (%s) failed (#%d): %v", which, n, err)
+	}
+}
+
+// monitoringDSNFromUpstream builds a libpq DSN for the monitoring connection.
+// Preference order: DATABASE_URL (operator-provided, full creds) → a best-effort
+// DSN from the upstream host:port (works when the proxy can auth as the same
+// role, e.g. trust/peer on loopback). Returns ("", false) if nothing usable.
+func monitoringDSNFromUpstream(upstreamAddr string) (string, bool) {
+	if env := strings.TrimSpace(getenv("DATABASE_URL")); env != "" {
+		return env, true
+	}
+	host, port := splitHostPort(upstreamAddr)
+	if host == "" {
+		return "", false
+	}
+	user := firstNonEmpty(getenv("FW_MONITOR_USER"), getenv("PGUSER"), "postgres")
+	dbname := firstNonEmpty(getenv("FW_MONITOR_DB"), getenv("PGDATABASE"), user)
+	dsn := fmt.Sprintf("host=%s port=%s user=%s dbname=%s sslmode=prefer connect_timeout=3",
+		host, port, user, dbname)
+	if pw := getenv("FW_MONITOR_PASSWORD"); pw != "" {
+		dsn += " password=" + pw
+	} else if pw := getenv("PGPASSWORD"); pw != "" {
+		dsn += " password=" + pw
+	}
+	return dsn, true
+}
+
+// openMonitoringDB opens (but does not verify) a small monitoring pool. The
+// caller pings; on failure the sampler simply runs without live state.
+func openMonitoringDB(dsn string) (*sql.DB, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(5 * time.Minute)
+	return db, nil
+}
+
+// ── small helpers (kept local to avoid colliding with existing utils) ──
+
+func getenv(k string) string { return strings.TrimSpace(os.Getenv(k)) }
+
+func splitHostPort(addr string) (string, string) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "", ""
+	}
+	if i := strings.LastIndex(addr, ":"); i >= 0 {
+		host := addr[:i]
+		port := addr[i+1:]
+		if host == "" {
+			host = "localhost"
+		}
+		if _, err := strconv.Atoi(port); err != nil {
+			port = "5432"
+		}
+		return host, port
+	}
+	return addr, "5432"
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/qwm_worldmodel.go
+++ b/qwm_worldmodel.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// ── RFC-003: QWM Query World Model — state-conditioned admission control ──
+//
+// IAM answers "is this agent allowed to run this query?". The world model
+// answers the gray-zone question: "given the LIVE state of the database, will
+// running this query breach the latency SLO?"
+//
+//	predicted_ms = base_service_ms(q) * congestion_factor(utilization ρ)
+//	             = base_fp            * 1/(1-ρ)            (M/M/c queuing prior)
+//	P_breach     = sigmoid(a * log(predicted_ms / SLO) + b)   (Platt-calibrated)
+//	decision     = reject iff P_breach > p_threshold
+//
+// Two hard lessons from the prototype, encoded here:
+//  1. base_service_ms is the query's own OBSERVED UNLOADED latency keyed by
+//     fingerprint — NOT the planner cost (Postgres mis-costs functions ~20×).
+//  2. utilization must be a FAST signal (active backends / cores), never the
+//     1-min loadavg, which lags real load by ~a minute → stale rejections.
+//
+// This file is the pure algorithm + model artifact + base-service store. The
+// live-state plumbing is in qwm_state.go; the proxy wiring is in proxy.go.
+
+// WorldModelArtifact is the on-disk model (schema faultwall.qwm.worldmodel.v1).
+type WorldModelArtifact struct {
+	Schema      string             `json:"schema"`
+	SLOms       float64            `json:"slo_ms"`
+	PThreshold  float64            `json:"p_threshold"`
+	Platt       PlattParams        `json:"platt"`
+	Servers     float64            `json:"servers"`
+	LowUtil     float64            `json:"low_util"`
+	BaseMsByFP  map[string]float64 `json:"base_ms_by_fp"`
+	Meta        map[string]any     `json:"meta,omitempty"`
+}
+
+// PlattParams are the logistic-calibration coefficients mapping the log-ratio of
+// predicted latency to SLO into a calibrated breach probability.
+type PlattParams struct {
+	A float64 `json:"a"`
+	B float64 `json:"b"`
+}
+
+// defaultWorldModel returns sane cold-start parameters so the scorer is useful
+// before any artifact is trained. These mirror the prototype's defaults: an 8s
+// SLO, reject at P>=0.5, and a Platt curve that puts P~0.5 right around
+// predicted==SLO (a·log(1)+b small) and saturates as predicted exceeds it.
+func defaultWorldModel() *WorldModelArtifact {
+	return &WorldModelArtifact{
+		Schema:     "faultwall.qwm.worldmodel.v1",
+		SLOms:      8000,
+		PThreshold: 0.5,
+		Platt:      PlattParams{A: 5.32, B: 1.72},
+		Servers:    1.0,
+		LowUtil:    0.35,
+		BaseMsByFP: map[string]float64{},
+	}
+}
+
+// LoadWorldModel reads an artifact from disk, filling defaults for any missing
+// field so a partial artifact (e.g. only platt + slo) still works.
+func LoadWorldModel(path string) (*WorldModelArtifact, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	wm := defaultWorldModel()
+	if err := json.Unmarshal(data, wm); err != nil {
+		return nil, err
+	}
+	if wm.SLOms <= 0 {
+		wm.SLOms = 8000
+	}
+	if wm.PThreshold <= 0 {
+		wm.PThreshold = 0.5
+	}
+	if wm.Servers <= 0 {
+		wm.Servers = 1.0
+	}
+	if wm.LowUtil <= 0 {
+		wm.LowUtil = 0.35
+	}
+	if wm.BaseMsByFP == nil {
+		wm.BaseMsByFP = map[string]float64{}
+	}
+	return wm, nil
+}
+
+// ── Pure algorithm (unit-tested independently of the proxy) ──
+
+// congestionFactor is the M/M/c-style queuing multiplier 1/(1-ρ). It clamps ρ
+// into [0, ρmax] so a saturated/over-subscribed DB (ρ>=1) yields a large-but-
+// finite inflation rather than +Inf, and an idle DB yields ~1.0 (no inflation).
+func congestionFactor(utilization, servers float64) float64 {
+	rho := utilization
+	if servers > 1 {
+		rho = utilization / servers
+	}
+	if rho < 0 {
+		rho = 0
+	}
+	// Clamp just below 1 so the factor is finite; ρ>=1 means "unstable", which
+	// we represent as a very large inflation (caps predicted_ms high → P→1).
+	const rhoMax = 0.995
+	if rho > rhoMax {
+		rho = rhoMax
+	}
+	return 1.0 / (1.0 - rho)
+}
+
+// predictedLatencyMs estimates how long query q will take given current load:
+// its unloaded base service time inflated by the congestion factor.
+func predictedLatencyMs(baseServiceMs, utilization, servers float64) float64 {
+	if baseServiceMs <= 0 {
+		return 0
+	}
+	return baseServiceMs * congestionFactor(utilization, servers)
+}
+
+// breachProbability maps predicted latency vs SLO into a calibrated P(breach)
+// via the Platt sigmoid. predicted<=0 (unknown base) → 0 (defer to fallback).
+func breachProbability(predictedMs, sloMs float64, p PlattParams) float64 {
+	if predictedMs <= 0 || sloMs <= 0 {
+		return 0
+	}
+	z := p.A*math.Log(predictedMs/sloMs) + p.B
+	return 1.0 / (1.0 + math.Exp(-z))
+}
+
+// ── Per-fingerprint base-service store (EWMA of unloaded latency) ──
+
+// baseServiceStore maintains an exponentially-weighted moving average of each
+// fingerprint's UNLOADED service time. Base is only updated when the DB is below
+// the low-utilization threshold, so it stays a clean "unloaded" estimate.
+type baseServiceStore struct {
+	mu    sync.RWMutex
+	ewma  map[string]float64
+	alpha float64 // EWMA weight for the new sample (0..1)
+}
+
+func newBaseServiceStore(alpha float64) *baseServiceStore {
+	if alpha <= 0 || alpha > 1 {
+		alpha = 0.2
+	}
+	return &baseServiceStore{ewma: map[string]float64{}, alpha: alpha}
+}
+
+// Observe records a measured latency for a fingerprint. It only updates the
+// unloaded base when utilization is below lowUtil (per RFC §4.1B); under load the
+// sample is inflated and would poison the base estimate, so it is ignored.
+func (b *baseServiceStore) Observe(fp string, latencyMs, utilization, lowUtil float64) {
+	if fp == "" || latencyMs <= 0 {
+		return
+	}
+	if utilization >= lowUtil {
+		return // not "unloaded" — don't pollute the base estimate
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if cur, ok := b.ewma[fp]; ok {
+		b.ewma[fp] = b.alpha*latencyMs + (1-b.alpha)*cur
+	} else {
+		b.ewma[fp] = latencyMs
+	}
+}
+
+// Base returns the EWMA base service time for a fingerprint, or (0,false) if the
+// fingerprint has never been observed under low load.
+func (b *baseServiceStore) Base(fp string) (float64, bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	v, ok := b.ewma[fp]
+	return v, ok
+}
+
+// Seed installs known base latencies from a model artifact (does not overwrite a
+// live-learned value that is already present).
+func (b *baseServiceStore) Seed(seed map[string]float64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for fp, ms := range seed {
+		if _, exists := b.ewma[fp]; !exists && ms > 0 {
+			b.ewma[fp] = ms
+		}
+	}
+}
+
+// ── worldModelScorer: implements QWMScorer ──
+
+// worldModelScorer is the RFC-003 scorer. It is state-conditioned: the same
+// query scores low at idle and high under load. On cold start (no base-service
+// data for a fingerprint) it falls back to the supplied shape-based scorer so we
+// never regress below the shipped behavior.
+type worldModelScorer struct {
+	artifact *WorldModelArtifact
+	base     *baseServiceStore
+	fallback QWMScorer // shape-based shadow scorer for unseen fingerprints
+}
+
+// NewWorldModelScorer builds a world-model scorer around an artifact + fallback.
+func NewWorldModelScorer(artifact *WorldModelArtifact, fallback QWMScorer) *worldModelScorer {
+	if artifact == nil {
+		artifact = defaultWorldModel()
+	}
+	bs := newBaseServiceStore(0.2)
+	bs.Seed(artifact.BaseMsByFP)
+	return &worldModelScorer{artifact: artifact, base: bs, fallback: fallback}
+}
+
+// Predict returns the predicted latency and calibrated breach probability for a
+// query under the given state. usedModel is false when we fell back to shape.
+func (w *worldModelScorer) Predict(pq *ParsedQuery, infra QWMInfraState) (predictedMs, pBreach float64, usedModel bool) {
+	if pq == nil {
+		return 0, 0, false
+	}
+	baseMs, known := w.base.Base(pq.Fingerprint)
+	if !known {
+		return 0, 0, false
+	}
+	predictedMs = predictedLatencyMs(baseMs, infra.Utilization, w.artifact.Servers)
+	pBreach = breachProbability(predictedMs, w.artifact.SLOms, w.artifact.Platt)
+	return predictedMs, pBreach, true
+}
+
+// Score implements QWMScorer. Returns P_breach when the world model has a base
+// for the fingerprint; otherwise defers to the shape-based fallback so unseen
+// queries still get a (shape) risk score during cold start.
+func (w *worldModelScorer) Score(pq *ParsedQuery, infra QWMInfraState) float64 {
+	if _, p, ok := w.Predict(pq, infra); ok {
+		return p
+	}
+	if w.fallback != nil {
+		return w.fallback.Score(pq, infra)
+	}
+	return 0
+}
+
+// TopFeatures implements QWMScorer with the world-model explainability triple.
+func (w *worldModelScorer) TopFeatures(pq *ParsedQuery, infra QWMInfraState, n int) []string {
+	predictedMs, _, ok := w.Predict(pq, infra)
+	if !ok {
+		if w.fallback != nil {
+			return w.fallback.TopFeatures(pq, infra, n)
+		}
+		return nil
+	}
+	baseMs, _ := w.base.Base(pq.Fingerprint)
+	cong := congestionFactor(infra.Utilization, w.artifact.Servers)
+	feats := []struct {
+		name string
+		mag  float64
+	}{
+		{"utilization", infra.Utilization},
+		{"congestion_factor", cong},
+		{"base_service_ms", baseMs / 1000.0},
+		{"predicted_ms", predictedMs / 1000.0},
+	}
+	sort.Slice(feats, func(i, j int) bool { return feats[i].mag > feats[j].mag })
+	if n > len(feats) {
+		n = len(feats)
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, feats[i].name)
+	}
+	return out
+}
+
+// Observe forwards a measured latency to the base-service store.
+func (w *worldModelScorer) Observe(fp string, latencyMs, utilization float64) {
+	w.base.Observe(fp, latencyMs, utilization, w.artifact.LowUtil)
+}
+
+// SLO/threshold accessors used by the decision logic in proxy.go.
+func (w *worldModelScorer) SLOms() float64      { return w.artifact.SLOms }
+func (w *worldModelScorer) PThreshold() float64 { return w.artifact.PThreshold }
+
+// worldModelStartTime anchors any time-based meta; kept for future use.
+var worldModelStartTime = time.Now()
+
+// loadWorldModelArtifact loads a trained artifact from FW_QWM_MODEL or
+// ~/.faultwall/qwm_world_model.json, falling back to cold-start defaults. Never
+// fails the proxy: a bad/missing artifact just yields the default model.
+func loadWorldModelArtifact() *WorldModelArtifact {
+	path := os.Getenv("FW_QWM_MODEL")
+	if path == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = home + "/.faultwall/qwm_world_model.json"
+		}
+	}
+	if path == "" {
+		return defaultWorldModel()
+	}
+	wm, err := LoadWorldModel(path)
+	if err != nil {
+		return defaultWorldModel()
+	}
+	return wm
+}
+
+// qwmConfiguredCores returns the core count used as the utilization denominator.
+// FW_QWM_CORES overrides; otherwise runtime.NumCPU(). Min 1.
+func qwmConfiguredCores() float64 {
+	if v := os.Getenv("FW_QWM_CORES"); v != "" {
+		if n, err := strconv.ParseFloat(v, 64); err == nil && n >= 1 {
+			return n
+		}
+	}
+	if n := runtime.NumCPU(); n >= 1 {
+		return float64(n)
+	}
+	return 1
+}

--- a/qwm_worldmodel_test.go
+++ b/qwm_worldmodel_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+// RFC-003 §8: same query admitted at idle, rejected under load.
+func TestWorldModel_SameQueryIdleVsHot(t *testing.T) {
+	wm := NewWorldModelScorer(defaultWorldModel(), nil)
+	fp := "abc123"
+	// Establish an unloaded base of 3s for this fingerprint (observed at idle).
+	wm.Observe(fp, 3000, 0.0)
+	if b, ok := wm.base.Base(fp); !ok || math.Abs(b-3000) > 1 {
+		t.Fatalf("base not learned: %v %v", b, ok)
+	}
+
+	pq := &ParsedQuery{Fingerprint: fp, Operation: "SELECT"}
+
+	// Idle: utilization ~0 → predicted ~= base (3s) which is < 8s SLO → low P.
+	idle := QWMInfraState{Utilization: 0.05}
+	predIdle, pbIdle, ok := wm.Predict(pq, idle)
+	if !ok {
+		t.Fatal("expected world model to apply (base known)")
+	}
+	if pbIdle > 0.3 {
+		t.Errorf("idle: expected low breach prob, got %.3f (predicted %.0fms)", pbIdle, predIdle)
+	}
+
+	// Hot: utilization 0.9 → congestion 1/(1-0.9)=10× → predicted ~30s ≫ 8s → P→1.
+	hot := QWMInfraState{Utilization: 0.9}
+	predHot, pbHot, _ := wm.Predict(pq, hot)
+	if pbHot < 0.9 {
+		t.Errorf("hot: expected high breach prob, got %.3f (predicted %.0fms)", pbHot, predHot)
+	}
+	if predHot <= predIdle {
+		t.Errorf("predicted latency must rise with load: idle=%.0f hot=%.0f", predIdle, predHot)
+	}
+}
+
+// RFC-003 §8: query×state aware — under identical high load a cheap query is
+// admitted while a heavy one is rejected.
+func TestWorldModel_CheapVsHeavyUnderSameLoad(t *testing.T) {
+	wm := NewWorldModelScorer(defaultWorldModel(), nil)
+	cheap := &ParsedQuery{Fingerprint: "cheap"}
+	heavy := &ParsedQuery{Fingerprint: "heavy"}
+	wm.Observe("cheap", 50, 0.0)   // 50ms unloaded
+	wm.Observe("heavy", 5000, 0.0) // 5s unloaded
+
+	load := QWMInfraState{Utilization: 0.8} // 5× inflation
+
+	_, pCheap, _ := wm.Predict(cheap, load)
+	_, pHeavy, _ := wm.Predict(heavy, load)
+
+	if pCheap > wm.PThreshold() {
+		t.Errorf("cheap query should be admitted under load, P=%.3f", pCheap)
+	}
+	if pHeavy < wm.PThreshold() {
+		t.Errorf("heavy query should be rejected under load, P=%.3f", pHeavy)
+	}
+}
+
+// Base service must only be learned at low utilization (unloaded), per §4.1B.
+func TestBaseServiceStore_OnlyLearnsUnloaded(t *testing.T) {
+	bs := newBaseServiceStore(0.5)
+	// Under load: ignored.
+	bs.Observe("fp", 9999, 0.9, 0.35)
+	if _, ok := bs.Base("fp"); ok {
+		t.Error("base should not be learned under load")
+	}
+	// Unloaded: learned.
+	bs.Observe("fp", 100, 0.1, 0.35)
+	if v, ok := bs.Base("fp"); !ok || v != 100 {
+		t.Errorf("base should be 100, got %v %v", v, ok)
+	}
+	// EWMA blends subsequent unloaded samples.
+	bs.Observe("fp", 200, 0.1, 0.35)
+	if v, _ := bs.Base("fp"); v != 150 { // 0.5*200 + 0.5*100
+		t.Errorf("EWMA expected 150, got %v", v)
+	}
+}
+
+// Congestion factor: idle ~1, saturated finite-large, ρ>=1 clamped.
+func TestCongestionFactor(t *testing.T) {
+	if c := congestionFactor(0, 1); math.Abs(c-1) > 1e-9 {
+		t.Errorf("idle congestion should be 1, got %v", c)
+	}
+	if c := congestionFactor(0.5, 1); math.Abs(c-2) > 1e-9 {
+		t.Errorf("ρ=0.5 → 2×, got %v", c)
+	}
+	if c := congestionFactor(1.5, 1); math.IsInf(c, 1) || c <= 0 {
+		t.Errorf("ρ>=1 must clamp to finite large, got %v", c)
+	}
+}
+
+// Cold start: unknown fingerprint falls back to the shape scorer, no panic.
+func TestWorldModel_ColdStartFallsBack(t *testing.T) {
+	fallback := NewShadowQWMScorer()
+	wm := NewWorldModelScorer(defaultWorldModel(), fallback)
+	pq := &ParsedQuery{Fingerprint: "never-seen", Operation: "DROP", Tables: []string{"users"}}
+	// No base for this fp → must use fallback (which scores DROP high), not 0.
+	got := wm.Score(pq, QWMInfraState{Utilization: 0.1})
+	want := fallback.Score(pq, QWMInfraState{Utilization: 0.1})
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("cold start should defer to fallback: got %.3f want %.3f", got, want)
+	}
+}
+
+// Breach probability is monotonic in predicted latency.
+func TestBreachProbabilityMonotonic(t *testing.T) {
+	p := PlattParams{A: 5.32, B: 1.72}
+	prev := -1.0
+	for _, ms := range []float64{1000, 4000, 8000, 16000, 32000} {
+		pb := breachProbability(ms, 8000, p)
+		if pb < prev {
+			t.Errorf("P_breach must be monotonic; dropped at %vms", ms)
+		}
+		prev = pb
+	}
+}

--- a/templates/qwm_world_model.example.json
+++ b/templates/qwm_world_model.example.json
@@ -1,0 +1,15 @@
+{
+  "schema": "faultwall.qwm.worldmodel.v1",
+  "slo_ms": 8000,
+  "p_threshold": 0.5,
+  "platt": { "a": 5.32, "b": 1.72 },
+  "servers": 1.0,
+  "low_util": 0.35,
+  "base_ms_by_fp": {},
+  "meta": {
+    "trained_at": "",
+    "dataset_rows": 0,
+    "git_sha": "",
+    "note": "Cold-start defaults. base_ms_by_fp is an optional seed; the proxy refines per-fingerprint base service live via EWMA (only updating when utilization < low_util). a/b are Platt coefficients for P_breach = sigmoid(a*ln(predicted_ms/slo_ms)+b)."
+  }
+}


### PR DESCRIPTION
## RFC-003 — QWM state-conditioned world model

Implements the novel QWM core: admission risk conditioned on the **live state of the database**.

```
predicted_ms = base_service_ms(q) * 1/(1-ρ)        (M/M/c queuing prior)
P_breach     = sigmoid(a*ln(predicted_ms/SLO) + b)  (Platt-calibrated)
```

- **qwm_worldmodel.go** — pure algorithm, per-fingerprint base-service EWMA (learns only under low load), `worldModelScorer` with shape-based fallback for unseen fingerprints (no cold-start regression), `faultwall.qwm.worldmodel.v1` artifact loader.
- **qwm_state.go** — `StateSampler` goroutine (~1s) reading `pg_stat_activity`; hot path reads a cached atomic snapshot (<0.2ms/query, no inline DB call); degrades to queuing-prior-only without a monitoring conn.
- **proxy.go / main.go** — live state replaces the `QWMInfraState{}` stub; forwarded-query latency fed back to the base EWMA keyed by fingerprint; flags carry `predicted_ms`/`p_breach`/`utilization`.

**Verified live** against real Postgres: idle query learned ~150ms base; under induced load (util=4 on 1 core) the same query predicted ~30s with p_breach≈1.0 and flagged. Unit tests cover §8 acceptance (idle-vs-hot, cheap-vs-heavy, unloaded-only base, monotonic P_breach, cold-start fallback). All `go test ./...` green.

**Shadow-only** — enforce/reject path (RFC §4.1D) intentionally not wired yet (runs the calibration period without blocking). Hosted-telemetry `qwm_flagged` metadata (§4.2 layer B) is follow-up.
