### PR TITLE
dashboard: local APA view + QWM flag reasons/conditions

### DIFF
--- a/firewall_api.go
+++ b/firewall_api.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/shreyasXV/faultwall/policygen/agent"
 )
 
 // handleFirewallAgents returns all known agents (active and historical)
@@ -152,6 +155,41 @@ func handleQWMFlags(w http.ResponseWriter, r *http.Request) {
 		"count":     len(flags),
 		"threshold": qwmFlagThreshold,
 		"observe_only": true,
+	})
+}
+
+// handleAPAProposals returns the local APA state so a self-host user can see
+// what APA is proposing without a control plane or PR setup (Soumya request):
+//   - per-agent allowed_fingerprints + pending_review (from the policy file)
+//   - recent APA runs (from the local audit log: confidence, PR url, errors)
+// GET /api/apa/proposals
+func handleAPAProposals(w http.ResponseWriter, r *http.Request) {
+	policyPath := os.Getenv("POLICY_FILE")
+	if policyPath == "" {
+		policyPath = "./policies.yaml"
+	}
+	auditPath := os.Getenv("APA_AUDIT_LOG")
+	if auditPath == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			auditPath = home + "/.faultwall/apa_audit.jsonl"
+		}
+	}
+
+	agents, err := agent.LoadAPAView(policyPath)
+	if err != nil {
+		agents = nil // policy unreadable — still return runs + empty agents
+	}
+	runs, _ := agent.LoadRecentAuditRecords(auditPath, 50)
+
+	pendingTotal := 0
+	for _, a := range agents {
+		pendingTotal += len(a.PendingReview)
+	}
+
+	writeJSON(w, map[string]interface{}{
+		"agents":        agents,
+		"recent_runs":   runs,
+		"pending_total": pendingTotal,
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -205,6 +205,7 @@ func main() {
 		mux.HandleFunc("/api/policies/reload", handlePoliciesReload)
 		mux.HandleFunc("/api/violations", handleViolations)
 		mux.HandleFunc("/api/qwm/flags", handleQWMFlags)
+		mux.HandleFunc("/api/apa/proposals", handleAPAProposals)
 		mux.HandleFunc("/api/rules/block", handleBlockRule)
 		mux.HandleFunc("/api/rules/preview", handleRulePreview)
 		mux.HandleFunc("/api/rules/create", handleRuleCreate)

--- a/policygen/agent/view.go
+++ b/policygen/agent/view.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"sort"
+)
+
+// ── Local APA visibility (dashboard / GET /api/apa/proposals) ──
+//
+// The proxy doesn't run APA inline (apa run/sync are separate invocations), so a
+// self-host user with no control plane and no PR setup couldn't SEE what APA is
+// proposing. These exported readers let the proxy surface APA state from the two
+// local artifacts: the policy file (current allowed/pending) and the audit log
+// (recent APA runs). No network, no control plane required.
+
+// AgentAPAView is the per-agent APA state exposed to the dashboard/API.
+type AgentAPAView struct {
+	AgentID             string            `json:"agent_id"`
+	AllowedFingerprints []FingerprintView `json:"allowed_fingerprints"`
+	PendingReview       []FingerprintView `json:"pending_review"`
+	BlockedOperations   []string          `json:"blocked_operations,omitempty"`
+	BlockedTables       []string          `json:"blocked_tables,omitempty"`
+}
+
+// FingerprintView is a JSON-friendly projection of a FingerprintRule.
+type FingerprintView struct {
+	Hash    string `json:"hash"`
+	SQL     string `json:"sql"`
+	Seen    int64  `json:"seen"`
+	Verdict string `json:"verdict"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+func toFingerprintViews(rules []FingerprintRule) []FingerprintView {
+	out := make([]FingerprintView, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, FingerprintView{Hash: r.Hash, SQL: r.SQL, Seen: r.Seen, Verdict: r.Verdict, Reason: r.Reason})
+	}
+	return out
+}
+
+// LoadAPAView reads the policy file and returns per-agent APA state, sorted by
+// agent id for stable output. Used by the local dashboard.
+func LoadAPAView(policyPath string) ([]AgentAPAView, error) {
+	agents, err := LoadAgentPolicies(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AgentAPAView, 0, len(agents))
+	for id, ap := range agents {
+		out = append(out, AgentAPAView{
+			AgentID:             id,
+			AllowedFingerprints: toFingerprintViews(ap.AllowedFingerprints),
+			PendingReview:       toFingerprintViews(ap.PendingReview),
+			BlockedOperations:   ap.BlockedOperations,
+			BlockedTables:       ap.BlockedTables,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AgentID < out[j].AgentID })
+	return out, nil
+}
+
+// LoadRecentAuditRecords reads up to `limit` most-recent APA run records from the
+// JSONL audit log (newest first). Missing file → empty slice, no error.
+func LoadRecentAuditRecords(auditPath string, limit int) ([]AuditRecord, error) {
+	f, err := os.Open(auditPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []AuditRecord{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var recs []AuditRecord
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	for sc.Scan() {
+		var r AuditRecord
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			continue // skip malformed lines
+		}
+		recs = append(recs, r)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	// newest first
+	sort.Slice(recs, func(i, j int) bool { return recs[i].Timestamp.After(recs[j].Timestamp) })
+	if limit > 0 && len(recs) > limit {
+		recs = recs[:limit]
+	}
+	return recs, nil
+}

--- a/proxy.go
+++ b/proxy.go
@@ -903,7 +903,8 @@ func scoreQueryShadow(agentLabel, query string, pq *ParsedQuery) {
 		top := qwmScorer.TopFeatures(pq, infra, 3)
 		logQWMFlag(agentLabel, query, score, top)
 
-		// RFC-003: enrich the flag with world-model predictions when available.
+		// RFC-003: enrich the flag with world-model predictions + the live DB
+		// conditions that drove it, so the user can see what's actually wrong.
 		rec := QWMFlagRecord{
 			Agent:       agentLabel,
 			Query:       querySnippet(query),
@@ -914,18 +915,35 @@ func scoreQueryShadow(agentLabel, query string, pq *ParsedQuery) {
 			Utilization: infra.Utilization,
 			Timestamp:   time.Now(),
 		}
+		var baseMs, congestion float64
+		usedModel := false
 		if wm, ok := qwmScorer.(*worldModelScorer); ok {
 			if predicted, pBreach, used := wm.Predict(pq, infra); used {
 				rec.PredictedMs = predicted
 				rec.PBreach = pBreach
+				usedModel = true
+				if b, known := wm.base.Base(pq.Fingerprint); known {
+					baseMs = b
+				}
+				congestion = congestionFactor(infra.Utilization, wm.artifact.Servers)
 			}
 		}
+		rec.Conditions = &FlagConditions{
+			ActiveBackends:  infra.ActiveBackends,
+			BlockedBackends: infra.BlockedBackends,
+			LongestActiveMs: infra.LongestActiveMs,
+			CacheHitRatio:   infra.CacheHitRatio,
+			TPS:             infra.TPS,
+			Utilization:     infra.Utilization,
+			BaseServiceMs:   baseMs,
+			CongestionX:     congestion,
+		}
+		rec.Reason = explainQWMFlag(pq, infra, rec, usedModel)
 		recordQWMFlag(rec)
 	}
 }
 
 // currentInfraState returns the live DB-state snapshot for the world model, or a
-// zero state (→ queuing-prior/fallback path) when no sampler is running.
 func currentInfraState() QWMInfraState {
 	if qwmStateSampler != nil {
 		return qwmStateSampler.Snapshot()
@@ -942,6 +960,65 @@ func recordQueryLatency(fingerprint string, latencyMs, utilization float64) {
 	if wm, ok := qwmScorer.(*worldModelScorer); ok {
 		wm.Observe(fingerprint, latencyMs, utilization)
 	}
+}
+
+// explainQWMFlag builds a plain-English reason for a flag so the user sees WHAT
+// is wrong with their database, not just "a query was risky". It distinguishes
+// the world-model (load-driven) path from the shape-based fallback path and
+// calls out the specific live conditions (high load, lock contention, low cache
+// hit, slow base query).
+func explainQWMFlag(pq *ParsedQuery, infra QWMInfraState, rec QWMFlagRecord, usedModel bool) string {
+	var parts []string
+
+	if usedModel && rec.PredictedMs > 0 {
+		// Load-driven world-model explanation: base × congestion → predicted vs SLO.
+		parts = append(parts, fmt.Sprintf(
+			"Under current load this query is predicted to take ~%.1fs (P(SLO breach)=%.0f%%).",
+			rec.PredictedMs/1000.0, rec.PBreach*100))
+		if rec.Conditions != nil && rec.Conditions.BaseServiceMs > 0 && rec.Conditions.CongestionX > 1 {
+			parts = append(parts, fmt.Sprintf(
+				"Its normal (unloaded) time is ~%.0fms, inflated ~%.1f× by current DB load.",
+				rec.Conditions.BaseServiceMs, rec.Conditions.CongestionX))
+		}
+	} else {
+		// Shape-based fallback: the query's shape is risky regardless of load.
+		parts = append(parts, fmt.Sprintf(
+			"Query shape scored risky (%s on %s).",
+			nonEmpty(pq.Operation, "operation"), tablesOrUnknown(pq.Tables)))
+	}
+
+	// Live DB conditions that contributed — these are the user's actual issues.
+	if infra.Utilization >= 0.8 {
+		parts = append(parts, fmt.Sprintf("Database is busy: %d active backend(s), utilization %.0f%%.",
+			infra.ActiveBackends, infra.Utilization*100))
+	}
+	if infra.BlockedBackends > 0 {
+		parts = append(parts, fmt.Sprintf("⚠ %d backend(s) blocked waiting on locks — lock contention.", infra.BlockedBackends))
+	}
+	if infra.LongestActiveMs >= 5000 {
+		parts = append(parts, fmt.Sprintf("Longest running query has been active %.1fs.", infra.LongestActiveMs/1000.0))
+	}
+	if infra.CacheHitRatio > 0 && infra.CacheHitRatio < 0.9 {
+		parts = append(parts, fmt.Sprintf("Low cache hit ratio (%.0f%%) — heavy disk reads.", infra.CacheHitRatio*100))
+	}
+	if len(parts) == 1 && infra.ActiveBackends > 0 {
+		parts = append(parts, fmt.Sprintf("(%d active backend(s) at flag time.)", infra.ActiveBackends))
+	}
+	return strings.Join(parts, " ")
+}
+
+func nonEmpty(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+func tablesOrUnknown(t []string) string {
+	if len(t) == 0 {
+		return "(no table)"
+	}
+	return strings.Join(t, ", ")
 }
 
 // recordObservation writes a query event to the global ObservationStore.

--- a/qwm_explain_test.go
+++ b/qwm_explain_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shreyasXV/faultwall/policygen/agent"
+)
+
+// QWM flag explanation: under-load world-model path mentions predicted latency
+// and the driving conditions, so the user sees what's wrong with their DB.
+func TestExplainQWMFlag_LoadDriven(t *testing.T) {
+	infra := QWMInfraState{ActiveBackends: 8, Utilization: 0.9, BlockedBackends: 2, LongestActiveMs: 6000}
+	rec := QWMFlagRecord{
+		PredictedMs: 22000, PBreach: 0.99,
+		Conditions: &FlagConditions{BaseServiceMs: 150, CongestionX: 10},
+	}
+	pq := &ParsedQuery{Operation: "SELECT", Tables: []string{"public.orders"}}
+	got := explainQWMFlag(pq, infra, rec, true)
+
+	for _, want := range []string{"predicted", "22.0s", "lock", "busy"} {
+		if !strings.Contains(strings.ToLower(got), strings.ToLower(want)) {
+			t.Errorf("explanation missing %q; got: %s", want, got)
+		}
+	}
+}
+
+// Shape-fallback path explains the query shape when no world-model base exists.
+func TestExplainQWMFlag_ShapeDriven(t *testing.T) {
+	infra := QWMInfraState{ActiveBackends: 1, Utilization: 0.1}
+	rec := QWMFlagRecord{}
+	pq := &ParsedQuery{Operation: "DROP", Tables: []string{"public.users"}}
+	got := explainQWMFlag(pq, infra, rec, false)
+	if !strings.Contains(strings.ToLower(got), "shape") {
+		t.Errorf("shape-driven explanation expected, got: %s", got)
+	}
+	if !strings.Contains(got, "DROP") {
+		t.Errorf("explanation should name the operation, got: %s", got)
+	}
+}
+
+// The flag record round-trips the conditions block (dashboard reads it).
+func TestQWMFlagRecord_CarriesConditions(t *testing.T) {
+	qwmFlagsMu.Lock()
+	qwmFlags = nil
+	qwmFlagsMu.Unlock()
+	recordQWMFlag(QWMFlagRecord{
+		Agent: "a", Query: "q", Score: 0.9,
+		Reason:     "Database is busy",
+		Conditions: &FlagConditions{ActiveBackends: 5, Utilization: 0.8, BlockedBackends: 1},
+	})
+	got := GetQWMFlags("")
+	if len(got) != 1 || got[0].Conditions == nil {
+		t.Fatal("conditions not preserved on flag record")
+	}
+	if got[0].Conditions.BlockedBackends != 1 {
+		t.Errorf("blocked backends not preserved: %+v", got[0].Conditions)
+	}
+}
+
+// Verify the local APA-proposals handler reads pending_review + audit from disk.
+func TestHandleAPAProposals_ReadsLocalState(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policies.yaml")
+	auditPath := filepath.Join(dir, "apa_audit.jsonl")
+	os.Setenv("POLICY_FILE", policyPath)
+	os.Setenv("APA_AUDIT_LOG", auditPath)
+	defer os.Unsetenv("POLICY_FILE")
+	defer os.Unsetenv("APA_AUDIT_LOG")
+
+	policy := `version: 1
+agents:
+  rb:
+    pending_review:
+      - hash: deadbeef
+        sql: "DELETE FROM orders"
+        seen: 1
+        verdict: pending
+        reason: "write op"
+`
+	if err := os.WriteFile(policyPath, []byte(policy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	audit := `{"run_id":"r1","timestamp":"2026-06-09T00:00:00Z","agent_id":"rb","provider":"litellm:bedrock-opus","pending_count":1,"confidence":0.82,"pr_url":"https://github.com/x/y/pull/1"}` + "\n"
+	if err := os.WriteFile(auditPath, []byte(audit), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exercise via the agent loaders the handler uses.
+	view, err := agent.LoadAPAView(policyPath)
+	if err != nil || len(view) != 1 || len(view[0].PendingReview) != 1 {
+		t.Fatalf("expected 1 agent with 1 pending, got %v err=%v", view, err)
+	}
+	if view[0].PendingReview[0].Reason != "write op" {
+		t.Errorf("pending reason not loaded: %+v", view[0].PendingReview[0])
+	}
+	runs, rerr := agent.LoadRecentAuditRecords(auditPath, 10)
+	if rerr != nil || len(runs) != 1 || runs[0].PRURL == "" {
+		t.Fatalf("expected 1 audit run with PR url, got %v err=%v", runs, rerr)
+	}
+}

--- a/qwm_shadow.go
+++ b/qwm_shadow.go
@@ -255,6 +255,25 @@ type QWMFlagRecord struct {
 	PredictedMs float64 `json:"predicted_ms,omitempty"`
 	PBreach     float64 `json:"p_breach,omitempty"`
 	Utilization float64 `json:"utilization,omitempty"`
+
+	// WHY this query was flagged: a plain-English explanation plus the live DB
+	// conditions at flag time, so the user can see what's actually wrong with
+	// their database (not just "a query was risky").
+	Reason     string         `json:"reason"`
+	Conditions *FlagConditions `json:"conditions,omitempty"`
+}
+
+// FlagConditions is the live DB state captured at the moment a query was flagged,
+// so the user can correlate the flag to what their database was actually doing.
+type FlagConditions struct {
+	ActiveBackends  int     `json:"active_backends"`
+	BlockedBackends int     `json:"blocked_backends"`  // waiting on a lock
+	LongestActiveMs float64 `json:"longest_active_ms"`  // oldest running query
+	CacheHitRatio   float64 `json:"cache_hit_ratio"`
+	TPS             float64 `json:"tps"`
+	Utilization     float64 `json:"utilization"`        // ρ = active backends / cores
+	BaseServiceMs   float64 `json:"base_service_ms,omitempty"` // learned unloaded latency for this fp
+	CongestionX     float64 `json:"congestion_x,omitempty"`    // inflation multiplier 1/(1-ρ)
 }
 
 const qwmFlagRingSize = 500

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -920,6 +920,18 @@
     </div>
   </div>
 
+  <!-- APA Proposals (Autonomous Policy Author) -->
+  <div class="card">
+    <div class="card-header">
+      <span class="card-title">🧠 APA Proposals</span>
+      <span class="card-subtitle" id="apa-pending-count">—</span>
+      <span class="card-subtitle" style="margin-left:8px; color:var(--muted);">what APA is proposing for your policy — review-gated, nothing auto-enforced</span>
+    </div>
+    <div id="apa-list">
+      <div class="empty">No APA activity yet. Run <code>faultwall apa sync</code> then <code>faultwall apa run</code> to generate proposals.</div>
+    </div>
+  </div>
+
   <!-- Connected Agents -->
   <div class="card">
     <div class="card-header">
@@ -1130,6 +1142,7 @@
   <a href="/api/agents/status" target="_blank">/agents</a> ·
   <a href="/api/violations" target="_blank">/violations</a> ·
   <a href="/api/qwm/flags" target="_blank">/qwm/flags</a> ·
+  <a href="/api/apa/proposals" target="_blank">/apa/proposals</a> ·
   <a href="/api/policies" target="_blank">/policies</a> ·
   <a href="/api/firewall/agents" target="_blank">/firewall</a>
 </footer>
@@ -1933,6 +1946,7 @@ async function refresh() {
     refreshThrottle();
     refreshViolations();
     refreshQWMFlags();
+    refreshAPAProposals();
     refreshAgentStats();
     refreshAgentConnections();
 
@@ -1983,6 +1997,22 @@ function renderQWMFlags(filter) {
     const score = (typeof x.score === 'number') ? x.score.toFixed(3) : '—';
     const feats = (x.top_features || []).join(', ');
     const tables = (x.tables || []).join(', ');
+    const c = x.conditions || {};
+    const condBits = [];
+    if (typeof c.utilization === 'number') condBits.push(`util ${(c.utilization*100).toFixed(0)}%`);
+    if (c.active_backends) condBits.push(`${c.active_backends} active`);
+    if (c.blocked_backends) condBits.push(`⚠ ${c.blocked_backends} lock-blocked`);
+    if (c.longest_active_ms >= 1000) condBits.push(`longest ${(c.longest_active_ms/1000).toFixed(1)}s`);
+    if (typeof c.cache_hit_ratio === 'number' && c.cache_hit_ratio > 0 && c.cache_hit_ratio < 0.9) condBits.push(`cache ${(c.cache_hit_ratio*100).toFixed(0)}%`);
+    if (c.base_service_ms) condBits.push(`base ${c.base_service_ms.toFixed(0)}ms`);
+    if (c.congestion_x > 1) condBits.push(`×${c.congestion_x.toFixed(1)} congestion`);
+    const predLine = (x.predicted_ms && x.p_breach)
+      ? `<div class="violation-meta" style="color:var(--red);">predicted ~${(x.predicted_ms/1000).toFixed(1)}s · P(SLO breach) ${(x.p_breach*100).toFixed(0)}%</div>`
+      : '';
+    const reasonLine = x.reason
+      ? `<div class="violation-meta" style="color:var(--fg);">${escHtml(x.reason)}</div>` : '';
+    const condLine = condBits.length
+      ? `<div class="violation-meta">DB conditions: ${escHtml(condBits.join(' · '))}</div>` : '';
     return `<div class="violation-item" style="border-left:3px solid var(--accent);">
       <span class="violation-icon">⚡</span>
       <div class="violation-body">
@@ -1993,6 +2023,9 @@ function renderQWMFlags(filter) {
           ${tables ? ' (tables: ' + escHtml(tables) + ')' : ''}
         </div>
         <div class="violation-query" title="${escHtml(x.query)}">${escHtml(x.query)}</div>
+        ${reasonLine}
+        ${predLine}
+        ${condLine}
         <div class="violation-meta">${feats ? 'top features: ' + escHtml(feats) + ' · ' : ''}${ts}</div>
       </div>
     </div>`;
@@ -2017,6 +2050,62 @@ async function refreshQWMFlags() {
   const fe = document.getElementById('qwm-filter');
   if (fe) fe.addEventListener('input', function(){ renderQWMFlags(this.value); });
 })();
+
+// ── APA Proposals (local visibility, no control plane needed) ──────────────
+async function refreshAPAProposals() {
+  const list = document.getElementById('apa-list');
+  if (!list) return;
+  try {
+    const data = await fetchJSON('/api/apa/proposals');
+    const agents = data.agents || [];
+    const runs = data.recent_runs || [];
+    const pending = data.pending_total || 0;
+    const countEl = document.getElementById('apa-pending-count');
+    if (countEl) countEl.textContent = pending > 0 ? pending + ' pending review' : (agents.length ? 'all clear' : 'no data');
+
+    let html = '';
+
+    // Pending review queue — the queries APA wants a human to decide on.
+    const pendingItems = [];
+    agents.forEach(a => (a.pending_review || []).forEach(fp => pendingItems.push({agent: a.agent_id, fp})));
+    if (pendingItems.length) {
+      html += '<div class="violation-meta" style="margin:4px 0; color:var(--muted);">Pending review</div>';
+      html += pendingItems.slice(0, 30).map(({agent, fp}) => `
+        <div class="violation-item" style="border-left:3px solid var(--accent);">
+          <span class="violation-icon">⏳</span>
+          <div class="violation-body">
+            <div class="violation-msg"><span class="violation-badge monitored">PENDING</span> Agent <strong>${escHtml(agent)}</strong> ${fp.verdict ? '· ' + escHtml(fp.verdict) : ''}</div>
+            <div class="violation-query" title="${escHtml(fp.sql || '')}">${escHtml(fp.sql || fp.hash || '')}</div>
+            ${fp.reason ? `<div class="violation-meta">${escHtml(fp.reason)}</div>` : ''}
+            <div class="violation-meta">seen ${fp.seen || 0}× · fingerprint ${escHtml((fp.hash||'').slice(0,16))}</div>
+          </div>
+        </div>`).join('');
+    }
+
+    // Recent APA runs — from the local audit log.
+    if (runs.length) {
+      html += '<div class="violation-meta" style="margin:8px 0 4px; color:var(--muted);">Recent APA runs</div>';
+      html += runs.slice(0, 10).map(r => {
+        const ts = r.timestamp ? timeAgo(r.timestamp) : '';
+        const conf = (typeof r.confidence === 'number' && r.confidence > 0) ? ` · confidence ${(r.confidence*100).toFixed(0)}%` : '';
+        const pr = r.pr_url ? ` · <a href="${escHtml(r.pr_url)}" target="_blank" style="color:var(--accent);">PR</a>` : '';
+        const err = r.error ? `<div class="violation-meta" style="color:var(--red);">error: ${escHtml(r.error)}</div>` : '';
+        return `<div class="violation-item">
+          <span class="violation-icon">${r.error ? '🔴' : '🧠'}</span>
+          <div class="violation-body">
+            <div class="violation-msg">Agent <strong>${escHtml(r.agent_id || '—')}</strong> · ${r.pending_count || 0} pending${conf}${pr}</div>
+            ${err}
+            <div class="violation-meta">${escHtml(r.provider || '')} · ${ts}</div>
+          </div>
+        </div>`;
+      }).join('');
+    }
+
+    list.innerHTML = html || '<div class="empty">No APA activity yet. Run <code>faultwall apa sync</code> then <code>faultwall apa run</code> to generate proposals.</div>';
+  } catch(e) {
+    list.innerHTML = '<div class="empty">APA endpoint unavailable</div>';
+  }
+}
 
 // Sparklines on separate interval (every 30s)
 setInterval(refreshSparklines, 30000);


### PR DESCRIPTION
## Local visibility for APA + QWM (Soumya requests)

**APA visible on localhost** (no control plane / PR setup needed):
- `GET /api/apa/proposals` → per-agent pending_review queue + recent APA runs (from the policy file + local audit log).
- Dashboard "APA Proposals" panel: pending queue with reasons + run history (confidence, PR link, errors).

**QWM flags now explain WHY** — the conditions/CPU state that drove the flag, so the user sees their actual DB issues:
- Flag records carry a plain-English `reason` + a `conditions` block (active/blocked backends, longest active query, cache hit ratio, tps, utilization, learned base service, congestion ×).
- Example (verified live): *"Under current load this query is predicted to take ~30.9s (P(SLO breach)=100%). Normal time ~154ms, inflated ~200× by load. DB busy: 4 active backends, utilization 400%."*

All observe-only. `go test ./...` green; verified end-to-end against real Postgres.
