### PR TITLE
Security: F2 search_path-aware allow, F3 spoof warning, F9 bypass detection (all guarded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,10 +414,11 @@ FaultWall exposes an MCP server so AI agents can self-monitor:
 
 ---
 
-## Known Limitations
+## Known Limitations & Hard Requirements
 
+- **DB-port isolation is REQUIRED.** FaultWall is a proxy. If agents can reach the upstream Postgres port directly (bypassing the proxy), every SQL-level rule in this repo is void and PII is exposed. Network policy / security groups / firewall rules MUST allow only the FaultWall proxy to reach the upstream DB port. At startup the proxy runs a best-effort TCP-dial probe (F9) and logs a warning describing what it observed; this is a topology hint, not proof of isolation. Disable with `FW_DB_ISOLATION_CHECK=false` if you've already verified isolation externally.
+- **Identity spoofing:** `application_name` is fully spoofable. Set `auth_token: <secret>` per agent in `policies.yaml` and have the agent send `agent:<id>:mission:<m>:token:<secret>`. To make tokenless agents fail-closed at the proxy, set `FW_REQUIRE_AUTH_TOKEN=true`. JWT-based identity attestation is on the roadmap.
 - **SSL/TLS:** Proxy mode currently denies SSL negotiation (client retries plaintext). For production with remote databases requiring TLS, use a TLS-terminating proxy in front of FaultWall.
-- **Identity spoofing:** `application_name` can be set by anyone. JWT-based identity attestation is on the roadmap.
 - **Fail-open:** If FaultWall's policy engine crashes, the query is forwarded (fail-open for availability). Configurable fail-closed mode is planned.
 
 ---

--- a/bypass_detect.go
+++ b/bypass_detect.go
@@ -1,0 +1,461 @@
+package main
+
+// REAL F9 — runtime bypass detection via pg_stat_activity reconciliation.
+//
+// The shipped F9 (RunDBIsolationProbe in guards.go) is a single-host TCP
+// dial: it tells you whether the proxy *can* reach the upstream from its
+// own host. That's a topology hint, not detection — it cannot prove an
+// agent has bypassed the proxy.
+//
+// This file implements actual bypass detection: it reconciles the set of
+// backends the proxy has originated against pg_stat_activity. Sessions
+// that look like agent connections (`application_name LIKE 'agent:%'`) but
+// whose PID is NOT in the proxy-owned set are strong evidence of a
+// bypass — the agent connected directly to the database port instead of
+// going through the proxy.
+//
+// This is OBSERVE-ONLY: we emit loud WARNINGs but do not kill or block
+// sessions (that would require privileged DB access, and is out of scope
+// for what FaultWall enforces today). The detection is gated by
+// `bypassDetectionOn` (default ON, observe-only is non-destructive) and
+// disablable via `FW_BYPASS_DETECTION=false`.
+
+import (
+	"database/sql"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Proxy-owned PID registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ProxyBackendRegistry tracks the upstream backend PIDs the proxy has
+// originated. Each upstream connection learns its PID from the
+// BackendKeyData ('K') wire message during auth; the proxy records it
+// here for the lifetime of the connection and removes it on close.
+//
+// The classifier uses this set as the ground truth for "the proxy
+// originated this session." A session whose PID is in this set was
+// established through the proxy. A session whose PID is NOT here, but
+// whose application_name claims to be an agent, is a candidate bypass.
+type ProxyBackendRegistry struct {
+	mu   sync.RWMutex
+	pids map[int]struct{}
+}
+
+// NewProxyBackendRegistry builds an empty registry.
+func NewProxyBackendRegistry() *ProxyBackendRegistry {
+	return &ProxyBackendRegistry{pids: make(map[int]struct{})}
+}
+
+// Register marks pid as proxy-owned. PID 0 is rejected (Postgres never
+// uses it; receiving 0 means we failed to parse BackendKeyData and we
+// don't want to claim every malformed session as ours).
+func (r *ProxyBackendRegistry) Register(pid int) {
+	if r == nil || pid <= 0 {
+		return
+	}
+	r.mu.Lock()
+	r.pids[pid] = struct{}{}
+	r.mu.Unlock()
+}
+
+// Deregister removes pid from the proxy-owned set. Safe to call with a
+// PID that was never registered (e.g. when BackendKeyData parsing failed
+// upstream).
+func (r *ProxyBackendRegistry) Deregister(pid int) {
+	if r == nil || pid <= 0 {
+		return
+	}
+	r.mu.Lock()
+	delete(r.pids, pid)
+	r.mu.Unlock()
+}
+
+// Has reports whether pid is currently registered.
+func (r *ProxyBackendRegistry) Has(pid int) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	_, ok := r.pids[pid]
+	r.mu.RUnlock()
+	return ok
+}
+
+// Size returns the current number of registered PIDs (for diagnostics).
+func (r *ProxyBackendRegistry) Size() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.pids)
+}
+
+// proxyBackendRegistry is the package-global instance the proxy and the
+// detector share. Initialized in main.go.
+var proxyBackendRegistry = NewProxyBackendRegistry()
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier
+// ─────────────────────────────────────────────────────────────────────────────
+
+// SessionRow is one row from pg_stat_activity, as the detector reads it.
+// Fields are kept narrow so the classifier is hermetic and unit-testable
+// without a real DB.
+type SessionRow struct {
+	PID             int
+	Username        string
+	ApplicationName string
+	ClientAddr      string
+	BackendType     string // 'client backend', 'autovacuum worker', 'walsender', etc.
+	State           string
+	Query           string
+}
+
+// BypassVerdict is what the classifier decides for one row.
+type BypassVerdict int
+
+const (
+	// VerdictProxyOwned means the session is one of the proxy's own
+	// upstream backends — never flag.
+	VerdictProxyOwned BypassVerdict = iota
+	// VerdictSystem means the session is a system/admin process Postgres
+	// runs internally (autovacuum, walsender, archiver, etc.) — never
+	// flag.
+	VerdictSystem
+	// VerdictBypassSuspected means the session looks like an agent
+	// connecting directly to the DB port (application_name has the
+	// `agent:` prefix and the PID is not proxy-owned) — flag.
+	VerdictBypassSuspected
+	// VerdictUnknown means we have no opinion: the session is not
+	// proxy-owned, doesn't claim an agent identity, and isn't a system
+	// process. We don't flag these to avoid false positives on
+	// legitimate maintenance/admin connections.
+	VerdictUnknown
+)
+
+// systemBackendTypes are pg_stat_activity backend_type values that are
+// internal Postgres machinery and never represent agent traffic.
+var systemBackendTypes = map[string]struct{}{
+	"autovacuum launcher":   {},
+	"autovacuum worker":     {},
+	"logical replication launcher": {},
+	"logical replication worker":   {},
+	"walsender":             {},
+	"walreceiver":           {},
+	"walwriter":             {},
+	"checkpointer":          {},
+	"background writer":     {},
+	"archiver":              {},
+	"startup":               {},
+	"background worker":     {},
+}
+
+// systemUsernames are role names Postgres / cloud providers use for
+// internal maintenance. Defensive: do not flag a bypass for these even
+// if backend_type is empty (some pg versions / proxies omit it).
+var systemUsernames = map[string]struct{}{
+	"rdsadmin":     {},
+	"rdsrepladmin": {},
+	"rds_superuser": {},
+	"cloudsqladmin": {},
+	"cloudsqlsuperuser": {},
+}
+
+// ClassifySession returns the bypass verdict for one pg_stat_activity row.
+// The function is pure: same inputs → same output, and it never panics
+// on empty/garbage data.
+func ClassifySession(row SessionRow, registry *ProxyBackendRegistry) BypassVerdict {
+	// Recover defensively in case future Postgres surfaces unexpected
+	// data — the loop must NEVER crash the proxy.
+	defer func() { _ = recover() }()
+
+	// (1) Anything the proxy registered is proxy-owned, full stop.
+	if registry != nil && registry.Has(row.PID) {
+		return VerdictProxyOwned
+	}
+	// (2) System backends.
+	if _, ok := systemBackendTypes[strings.ToLower(strings.TrimSpace(row.BackendType))]; ok {
+		return VerdictSystem
+	}
+	if _, ok := systemUsernames[strings.ToLower(strings.TrimSpace(row.Username))]; ok {
+		return VerdictSystem
+	}
+	// (3) Agent-looking session that the proxy did NOT originate.
+	app := strings.TrimSpace(row.ApplicationName)
+	if strings.HasPrefix(app, "agent:") {
+		return VerdictBypassSuspected
+	}
+	// (4) Unknown legitimate connection (psql admin, monitoring tools,
+	// migration scripts, etc.). We deliberately do not flag these — the
+	// security promise is that AGENTS go through the proxy. Other DB
+	// users have their own access controls.
+	return VerdictUnknown
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Guard + poller
+// ─────────────────────────────────────────────────────────────────────────────
+
+// bypassDetectionOn gates the runtime poller. Default ON because the
+// detector is observe-only (non-destructive). Operators can disable it
+// with FW_BYPASS_DETECTION=false.
+var bypassDetectionOn atomic.Bool
+
+// IsBypassDetectionOn reports the current gate state.
+func IsBypassDetectionOn() bool { return bypassDetectionOn.Load() }
+
+// setBypassDetection is the test seam.
+func setBypassDetection(on bool) { bypassDetectionOn.Store(on) }
+
+// InitBypassDetectionGuard reads FW_BYPASS_DETECTION and runs the
+// classifier self-check. Self-check failure → gate OFF + WARNING (we
+// would rather not warn at all than emit bogus alerts; operators will
+// re-investigate). Default ON unless explicitly disabled.
+func InitBypassDetectionGuard() {
+	want := strings.ToLower(strings.TrimSpace(os.Getenv("FW_BYPASS_DETECTION")))
+	if want == "false" || want == "0" || want == "off" {
+		bypassDetectionOn.Store(false)
+		log.Printf("REAL-F9 bypass detection DISABLED via FW_BYPASS_DETECTION=%s. " +
+			"FaultWall will not warn on direct-to-DB agent connections; verify network "+
+			"isolation through external means.", want)
+		return
+	}
+	if !bypassClassifierSelfCheckFn() {
+		bypassDetectionOn.Store(false)
+		log.Printf("⚠️  REAL-F9 self-check FAILED: bypass classifier gave incorrect verdicts on " +
+			"synthetic input. Detection disabled (gate OFF) so we don't emit bogus warnings. " +
+			"DB-port isolation remains a HARD REQUIREMENT regardless — verify externally.")
+		return
+	}
+	bypassDetectionOn.Store(true)
+	log.Printf("✅ REAL-F9 guard active: bypass detection runs on each pg_stat_activity poll. " +
+		"Observe-only — agents that connect direct-to-DB will be logged as suspected " +
+		"bypasses, not blocked. Disable with FW_BYPASS_DETECTION=false.")
+}
+
+// bypassClassifierSelfCheckFn is the test seam for fault injection.
+var bypassClassifierSelfCheckFn = bypassDetectionClassifierSelfCheckPass
+
+// bypassDetectionClassifierSelfCheckPass exercises the four classifier
+// contracts the spec calls out:
+//
+//	(a) a proxy-owned backend is NOT flagged
+//	(b) an agent-looking session not in the tracked set IS flagged
+//	(c) system/replication/autovacuum sessions are NOT flagged
+//	(d) classifier never panics on empty/garbage rows
+func bypassDetectionClassifierSelfCheckPass() bool {
+	reg := NewProxyBackendRegistry()
+	reg.Register(123)
+
+	// (a)
+	v := ClassifySession(SessionRow{PID: 123, ApplicationName: "agent:x:mission:m"}, reg)
+	if v != VerdictProxyOwned {
+		return false
+	}
+	// (b)
+	v = ClassifySession(SessionRow{PID: 999, ApplicationName: "agent:x:mission:m", BackendType: "client backend"}, reg)
+	if v != VerdictBypassSuspected {
+		return false
+	}
+	// (c)
+	v = ClassifySession(SessionRow{PID: 222, BackendType: "autovacuum worker"}, reg)
+	if v != VerdictSystem {
+		return false
+	}
+	v = ClassifySession(SessionRow{PID: 333, BackendType: "walsender", Username: "rds_replication"}, reg)
+	if v != VerdictSystem {
+		return false
+	}
+	// (d) garbage input must not panic and must classify as Unknown
+	v = ClassifySession(SessionRow{}, reg)
+	if v != VerdictUnknown {
+		return false
+	}
+	v = ClassifySession(SessionRow{PID: -1, ApplicationName: "\x00\x01garbage", BackendType: "\x00"}, reg)
+	if v != VerdictUnknown {
+		return false
+	}
+	return true
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Poller + warning dedupe
+// ─────────────────────────────────────────────────────────────────────────────
+
+// BypassDetector runs a background poll loop, calling out to a row source
+// (function pointer / interface — for hermetic testing). Production wires
+// it up to a real *sql.DB; tests inject synthetic rows.
+type BypassDetector struct {
+	registry *ProxyBackendRegistry
+	source   BypassRowSource
+	interval time.Duration
+
+	mu    sync.Mutex
+	seen  map[int]bool // pids we've already warned about this appearance
+
+	stopOnce sync.Once
+	stop     chan struct{}
+}
+
+// BypassRowSource abstracts the pg_stat_activity read so tests can inject
+// synthetic rows. A returned error logs a warning and the loop continues
+// (graceful degradation — never crashes the proxy).
+type BypassRowSource interface {
+	Snapshot() ([]SessionRow, error)
+}
+
+// NewBypassDetector builds a detector. interval <=0 defaults to 30s.
+func NewBypassDetector(reg *ProxyBackendRegistry, src BypassRowSource, interval time.Duration) *BypassDetector {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	return &BypassDetector{
+		registry: reg,
+		source:   src,
+		interval: interval,
+		seen:     make(map[int]bool),
+		stop:     make(chan struct{}),
+	}
+}
+
+// Start launches the poll goroutine. Safe to call once. The detector
+// runs only when the gate is ON; if the gate is flipped OFF after start,
+// the loop short-circuits each tick.
+func (d *BypassDetector) Start() {
+	if d == nil || d.source == nil {
+		return
+	}
+	go func() {
+		// Prime once so operators get fast feedback in dev.
+		d.tick()
+		ticker := time.NewTicker(d.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-d.stop:
+				return
+			case <-ticker.C:
+				d.tick()
+			}
+		}
+	}()
+}
+
+// Stop ends the poll goroutine.
+func (d *BypassDetector) Stop() {
+	if d == nil {
+		return
+	}
+	d.stopOnce.Do(func() { close(d.stop) })
+}
+
+// tick performs one poll cycle. Public-on-receiver because tests drive it
+// directly (deterministic) instead of waiting on the ticker.
+func (d *BypassDetector) Tick() { d.tick() }
+
+func (d *BypassDetector) tick() {
+	if !IsBypassDetectionOn() {
+		return
+	}
+	rows, err := d.source.Snapshot()
+	if err != nil {
+		// Per spec: a query error is non-fatal. Log a warning, continue.
+		log.Printf("⚠️  REAL-F9 bypass detector: pg_stat_activity snapshot failed: %v "+
+			"(non-fatal; will retry on next tick)", err)
+		return
+	}
+	d.classifyAndWarn(rows)
+}
+
+// classifyAndWarn applies the classifier to each row and emits warnings
+// for newly-seen bypass suspects. Dedupe rule: warn ONCE per (pid,
+// appearance). If a pid disappears from a subsequent poll and reappears,
+// it is warned again.
+func (d *BypassDetector) classifyAndWarn(rows []SessionRow) {
+	currentSuspects := make(map[int]bool)
+	for _, row := range rows {
+		v := ClassifySession(row, d.registry)
+		if v != VerdictBypassSuspected {
+			continue
+		}
+		currentSuspects[row.PID] = true
+		d.mu.Lock()
+		alreadyWarned := d.seen[row.PID]
+		if !alreadyWarned {
+			d.seen[row.PID] = true
+		}
+		d.mu.Unlock()
+		if !alreadyWarned {
+			log.Printf("🚨 REAL-F9 BYPASS SUSPECTED: agent-like session NOT originated by proxy. "+
+				"pid=%d application_name=%q usename=%q client_addr=%q backend_type=%q. "+
+				"This session reaches the database WITHOUT FaultWall in front of it — the "+
+				"SQL-level enforcement promise is VOID for this session. Verify network "+
+				"isolation: the agent should not be able to reach the DB port directly. "+
+				"FaultWall is observe-only here; it will not kill the session.",
+				row.PID, row.ApplicationName, row.Username, row.ClientAddr, row.BackendType)
+		}
+	}
+	// Sweep `seen`: drop pids that have disappeared since the last poll
+	// so a returning bypass is warned again. We rebuild the map from the
+	// intersection of current suspects + previously-seen still-present.
+	d.mu.Lock()
+	for pid := range d.seen {
+		if !currentSuspects[pid] {
+			delete(d.seen, pid)
+		}
+	}
+	d.mu.Unlock()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Real DB-backed row source
+// ─────────────────────────────────────────────────────────────────────────────
+
+// dbBypassRowSource is the production BypassRowSource backed by a
+// monitoring sql.DB connection.
+type dbBypassRowSource struct {
+	db *sql.DB
+}
+
+// NewDBBypassRowSource wraps an *sql.DB.
+func NewDBBypassRowSource(db *sql.DB) BypassRowSource {
+	return &dbBypassRowSource{db: db}
+}
+
+// Snapshot reads pg_stat_activity. backend_type was added in pg10; we
+// COALESCE it to '' for older versions so the classifier sees a stable
+// shape.
+func (s *dbBypassRowSource) Snapshot() ([]SessionRow, error) {
+	rows, err := s.db.Query(`
+		SELECT pid,
+		       COALESCE(usename, ''),
+		       COALESCE(application_name, ''),
+		       COALESCE(client_addr::text, ''),
+		       COALESCE(backend_type, ''),
+		       COALESCE(state, ''),
+		       COALESCE(query, '')
+		FROM pg_stat_activity
+		WHERE pid <> pg_backend_pid()`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []SessionRow
+	for rows.Next() {
+		var r SessionRow
+		if err := rows.Scan(&r.PID, &r.Username, &r.ApplicationName, &r.ClientAddr,
+			&r.BackendType, &r.State, &r.Query); err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/bypass_detect_test.go
+++ b/bypass_detect_test.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier contracts (a)–(d)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// (a) A proxy-owned backend is NOT flagged.
+func TestRealF9_Classifier_ProxyOwnedNotFlagged(t *testing.T) {
+	reg := NewProxyBackendRegistry()
+	reg.Register(101)
+	v := ClassifySession(SessionRow{
+		PID:             101,
+		ApplicationName: "agent:billing:mission:read",
+		BackendType:     "client backend",
+	}, reg)
+	if v != VerdictProxyOwned {
+		t.Errorf("contract (a): proxy-owned PID 101 must classify as VerdictProxyOwned, got %v", v)
+	}
+}
+
+// (b) An agent-looking session NOT in the tracked set IS flagged.
+func TestRealF9_Classifier_AgentNotInRegistryFlagged(t *testing.T) {
+	reg := NewProxyBackendRegistry() // empty
+	v := ClassifySession(SessionRow{
+		PID:             999,
+		ApplicationName: "agent:billing:mission:read",
+		BackendType:     "client backend",
+		ClientAddr:      "10.0.0.7",
+	}, reg)
+	if v != VerdictBypassSuspected {
+		t.Errorf("contract (b): unregistered agent-like session must classify as VerdictBypassSuspected, got %v", v)
+	}
+}
+
+// (c) System / replication / autovacuum sessions are NOT flagged.
+func TestRealF9_Classifier_SystemNotFlagged(t *testing.T) {
+	reg := NewProxyBackendRegistry()
+	cases := []SessionRow{
+		{PID: 1, BackendType: "autovacuum worker"},
+		{PID: 2, BackendType: "walsender"},
+		{PID: 3, BackendType: "logical replication launcher"},
+		{PID: 4, BackendType: "checkpointer"},
+		{PID: 5, BackendType: "background writer"},
+		{PID: 6, BackendType: "archiver"},
+		{PID: 7, Username: "rdsadmin"},
+		{PID: 8, Username: "cloudsqladmin", BackendType: "client backend"},
+	}
+	for i, row := range cases {
+		v := ClassifySession(row, reg)
+		if v != VerdictSystem {
+			t.Errorf("contract (c) case %d: %+v must classify as VerdictSystem, got %v", i, row, v)
+		}
+	}
+}
+
+// (d) Empty / garbage rows must not panic and must classify as Unknown.
+func TestRealF9_Classifier_EmptyAndGarbageNoPanic(t *testing.T) {
+	reg := NewProxyBackendRegistry()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("classifier panicked on garbage input: %v", r)
+		}
+	}()
+	if v := ClassifySession(SessionRow{}, reg); v != VerdictUnknown {
+		t.Errorf("contract (d): empty row must classify Unknown, got %v", v)
+	}
+	if v := ClassifySession(SessionRow{
+		PID:             -1,
+		ApplicationName: "\x00\x01garbage",
+		BackendType:     "\x00",
+		Username:        "\x7f",
+	}, reg); v != VerdictUnknown {
+		t.Errorf("contract (d): garbage row must classify Unknown, got %v", v)
+	}
+}
+
+// Non-agent client backends (psql admin, monitoring) are NOT flagged.
+func TestRealF9_Classifier_NonAgentClientBackendIsUnknown(t *testing.T) {
+	reg := NewProxyBackendRegistry()
+	v := ClassifySession(SessionRow{
+		PID:             50,
+		ApplicationName: "psql",
+		BackendType:     "client backend",
+		Username:        "alice",
+	}, reg)
+	if v != VerdictUnknown {
+		t.Errorf("non-agent client backend must classify Unknown (no false positive), got %v", v)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRealF9_Registry_RegisterDeregister(t *testing.T) {
+	reg := NewProxyBackendRegistry()
+	if reg.Has(42) {
+		t.Error("fresh registry should not have PID 42")
+	}
+	reg.Register(42)
+	if !reg.Has(42) {
+		t.Error("after Register, registry must Have the PID")
+	}
+	reg.Deregister(42)
+	if reg.Has(42) {
+		t.Error("after Deregister, registry must not Have the PID")
+	}
+	// Defensive: 0 / negative are no-ops.
+	reg.Register(0)
+	reg.Register(-1)
+	if reg.Size() != 0 {
+		t.Error("PID 0 and negative must be ignored")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Detector dedupe + error handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+// fakeRowSource is a test BypassRowSource. Returns the configured rows or
+// the configured error.
+type fakeRowSource struct {
+	rows []SessionRow
+	err  error
+}
+
+func (f *fakeRowSource) Snapshot() ([]SessionRow, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rows, nil
+}
+
+// Same suspect PID across two consecutive ticks = warn ONCE.
+func TestRealF9_Detector_DedupeAcrossTicks(t *testing.T) {
+	prev := IsBypassDetectionOn()
+	defer setBypassDetection(prev)
+	setBypassDetection(true)
+
+	reg := NewProxyBackendRegistry()
+	src := &fakeRowSource{rows: []SessionRow{
+		{PID: 999, ApplicationName: "agent:x:mission:m", BackendType: "client backend"},
+	}}
+	d := NewBypassDetector(reg, src, time.Second)
+	out := captureLog(t, func() {
+		d.Tick() // first observation → warn
+		d.Tick() // same row, same tick → no second warn
+	})
+	if c := strings.Count(out, "BYPASS SUSPECTED"); c != 1 {
+		t.Errorf("dedupe: expected exactly 1 warning across 2 ticks for same pid, got %d. log:\n%s", c, out)
+	}
+}
+
+// Suspect PID disappears, then returns: warn AGAIN.
+func TestRealF9_Detector_RewarnAfterDisappearance(t *testing.T) {
+	prev := IsBypassDetectionOn()
+	defer setBypassDetection(prev)
+	setBypassDetection(true)
+
+	reg := NewProxyBackendRegistry()
+	src := &fakeRowSource{}
+	d := NewBypassDetector(reg, src, time.Second)
+
+	// Round 1: suspect present
+	src.rows = []SessionRow{
+		{PID: 999, ApplicationName: "agent:x:mission:m", BackendType: "client backend"},
+	}
+	out1 := captureLog(t, func() { d.Tick() })
+	if !strings.Contains(out1, "BYPASS SUSPECTED") {
+		t.Fatalf("round 1: expected warning, got: %s", out1)
+	}
+
+	// Round 2: suspect gone
+	src.rows = nil
+	captureLog(t, func() { d.Tick() })
+
+	// Round 3: same suspect returns → must warn again
+	src.rows = []SessionRow{
+		{PID: 999, ApplicationName: "agent:x:mission:m", BackendType: "client backend"},
+	}
+	out3 := captureLog(t, func() { d.Tick() })
+	if !strings.Contains(out3, "BYPASS SUSPECTED") {
+		t.Errorf("round 3: returning suspect must be warned again, got: %s", out3)
+	}
+}
+
+// FW_BYPASS_DETECTION=false disables the detector entirely.
+func TestRealF9_Env_FalseDisablesDetection(t *testing.T) {
+	prevEnv, hadEnv := os.LookupEnv("FW_BYPASS_DETECTION")
+	prevGate := IsBypassDetectionOn()
+	defer func() {
+		if hadEnv {
+			os.Setenv("FW_BYPASS_DETECTION", prevEnv)
+		} else {
+			os.Unsetenv("FW_BYPASS_DETECTION")
+		}
+		setBypassDetection(prevGate)
+	}()
+	os.Setenv("FW_BYPASS_DETECTION", "false")
+
+	out := captureLog(t, func() { InitBypassDetectionGuard() })
+	if IsBypassDetectionOn() {
+		t.Errorf("FW_BYPASS_DETECTION=false must disable the gate, got ON")
+	}
+	if !strings.Contains(out, "DISABLED") {
+		t.Errorf("expected DISABLED log when env disables detection, got: %s", out)
+	}
+}
+
+// pg_stat_activity query error → log warning, continue without crash.
+func TestRealF9_Detector_QueryErrorIsNonFatal(t *testing.T) {
+	prev := IsBypassDetectionOn()
+	defer setBypassDetection(prev)
+	setBypassDetection(true)
+
+	reg := NewProxyBackendRegistry()
+	src := &fakeRowSource{err: errors.New("synthetic snapshot error")}
+	d := NewBypassDetector(reg, src, time.Second)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Tick must not panic on snapshot error, got: %v", r)
+		}
+	}()
+	out := captureLog(t, func() { d.Tick() })
+	if !strings.Contains(out, "snapshot failed") {
+		t.Errorf("expected snapshot-failed warning, got: %s", out)
+	}
+	if !strings.Contains(out, "non-fatal") {
+		t.Errorf("warning should describe error as non-fatal, got: %s", out)
+	}
+}
+
+// Self-check engages the gate on the canonical happy case.
+func TestRealF9_SelfCheckEngagesGuard(t *testing.T) {
+	prev := IsBypassDetectionOn()
+	prevEnv, hadEnv := os.LookupEnv("FW_BYPASS_DETECTION")
+	defer func() {
+		setBypassDetection(prev)
+		if hadEnv {
+			os.Setenv("FW_BYPASS_DETECTION", prevEnv)
+		} else {
+			os.Unsetenv("FW_BYPASS_DETECTION")
+		}
+	}()
+	os.Unsetenv("FW_BYPASS_DETECTION")
+	setBypassDetection(false)
+
+	out := captureLog(t, func() { InitBypassDetectionGuard() })
+	if !IsBypassDetectionOn() {
+		t.Errorf("self-check should pass on canonical case — guard expected ON. log: %s", out)
+	}
+	if !strings.Contains(out, "REAL-F9 guard active") {
+		t.Errorf("expected REAL-F9 guard-active log, got: %s", out)
+	}
+}
+
+// Self-check failure path: inject a broken classifier seam → guard OFF.
+func TestRealF9_SelfCheckFailureFallsBack(t *testing.T) {
+	prev := IsBypassDetectionOn()
+	prevEnv, hadEnv := os.LookupEnv("FW_BYPASS_DETECTION")
+	prevSeam := bypassClassifierSelfCheckFn
+	defer func() {
+		setBypassDetection(prev)
+		if hadEnv {
+			os.Setenv("FW_BYPASS_DETECTION", prevEnv)
+		} else {
+			os.Unsetenv("FW_BYPASS_DETECTION")
+		}
+		bypassClassifierSelfCheckFn = prevSeam
+	}()
+	os.Unsetenv("FW_BYPASS_DETECTION")
+	bypassClassifierSelfCheckFn = func() bool { return false }
+	setBypassDetection(true) // start ON to prove fallback flips it OFF
+
+	out := captureLog(t, func() { InitBypassDetectionGuard() })
+	if IsBypassDetectionOn() {
+		t.Errorf("broken self-check must DISABLE detection, got ON. log: %s", out)
+	}
+	if !strings.Contains(out, "REAL-F9 self-check FAILED") {
+		t.Errorf("expected REAL-F9 self-check FAILED warning, got: %s", out)
+	}
+}
+
+// Gate OFF → tick is a no-op (no warning, no snapshot read).
+type panicSource struct{}
+
+func (panicSource) Snapshot() ([]SessionRow, error) {
+	panic("snapshot must not be called when gate is OFF")
+}
+
+func TestRealF9_Detector_GateOffSkipsSnapshot(t *testing.T) {
+	prev := IsBypassDetectionOn()
+	defer setBypassDetection(prev)
+	setBypassDetection(false)
+
+	reg := NewProxyBackendRegistry()
+	d := NewBypassDetector(reg, panicSource{}, time.Second)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("gate OFF must short-circuit Tick (no source call), but it panicked: %v", r)
+		}
+	}()
+	d.Tick()
+}

--- a/guards.go
+++ b/guards.go
@@ -1,0 +1,367 @@
+package main
+
+// Self-disabling feature guards.
+//
+// Each new behavior in this file is gated behind an explicit enable plus a
+// startup self-check. If the self-check disagrees with what the new behavior
+// is supposed to do, the feature disables itself and the proxy falls back to
+// the prior, safe path with a logged WARNING. The rule is: never silently
+// ship a broken fix; for security, fail-safe means closed (deny / preserve
+// existing block / preserve warn-only).
+//
+// Three features live here:
+//
+//   F2 — unqualified-name allow-path normalization
+//        (isTableAllowed treats bare "feedback" as "public.feedback" for
+//        ALLOW matching only; never loosens BLOCK matching)
+//
+//   F3 — spoofable-identity startup warning + optional require_auth_token
+//        enforcement
+//
+//   F9 — best-effort DB-port isolation self-probe (warn-only)
+
+import (
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F2 — unqualified-name allow-path normalization guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+// unqualifiedAllowNormalizationOn is the runtime gate consulted by
+// isTableAllowed. It defaults to 0 (off / current behavior) and is only
+// flipped to 1 if InitUnqualifiedAllowGuard's self-check passes.
+//
+// When OFF: isTableAllowed behaves exactly as before; an unqualified bare
+// table name like "feedback" does not match an allow entry of "public.*",
+// so the agent gets table_not_in_mission. (This is the pre-fix state.)
+//
+// When ON: an unqualified bare reference is normalized to the configured
+// default schema (almost always "public") for the ALLOW match, so that
+// "feedback" matches an allow entry of "public.*" or "public.feedback".
+// Schema-qualified references are unaffected. The BLOCK path is never
+// touched.
+var unqualifiedAllowNormalizationOn atomic.Bool
+
+// defaultSchemaForAllowMatch is the schema prepended to unqualified table
+// references when the allow-path normalization is on. Postgres' default
+// search_path puts "public" first, so this is the operationally correct
+// choice. We keep it as a package-level so tests can swap it.
+var defaultSchemaForAllowMatch = "public"
+
+// IsUnqualifiedAllowNormalizationOn reports whether the F2 normalization
+// guard is currently enabled. Exposed for tests and diagnostic logging.
+func IsUnqualifiedAllowNormalizationOn() bool {
+	return unqualifiedAllowNormalizationOn.Load()
+}
+
+// setUnqualifiedAllowNormalization is for tests to toggle the gate without
+// going through the self-check.
+func setUnqualifiedAllowNormalization(on bool) {
+	unqualifiedAllowNormalizationOn.Store(on)
+}
+
+// InitUnqualifiedAllowGuard runs the F2 self-check and engages the guard if
+// the check confirms the normalization is correct. The contract checked is:
+//
+//   1. Bare "feedback" must match an allow list of {"public.*"}.
+//      (The bug: pre-fix this returned false because "feedback" doesn't
+//      have the "public." prefix. The fix: normalize to "public.feedback"
+//      for the allow match.)
+//
+//   2. Bare "feedback" must NOT match an allow list of {"public.users"}.
+//      (Verifies the normalization didn't slip into a "match anything in
+//      the schema" wildcard.)
+//
+//   3. A schema-qualified reference outside the allow list must still be
+//      blocked: "secret.keys" must not match {"public.*"}. This guards
+//      against an over-eager normalization that loses the schema.
+//
+// If any check disagrees, we log a clear WARNING, leave the guard OFF, and
+// the proxy falls back to the original (stricter) isTableAllowed behavior.
+func InitUnqualifiedAllowGuard() {
+	if !unqualifiedAllowNormalizationCandidatePass() {
+		log.Printf("⚠️  F2 self-check FAILED: unqualified-name allow-path normalization disabled. "+
+			"isTableAllowed will fall back to the prior (block-on-bare-name) behavior. "+
+			"Agents emitting unqualified ORM table names may be over-blocked under public.* allow lists. "+
+			"This is a fail-safe (closed) state, not a security regression.")
+		unqualifiedAllowNormalizationOn.Store(false)
+		return
+	}
+	unqualifiedAllowNormalizationOn.Store(true)
+	log.Printf("✅ F2 guard active: unqualified table names will be normalized to %q for ALLOW matching only "+
+		"(BLOCK matching is unchanged).", defaultSchemaForAllowMatch+".<name>")
+}
+
+// unqualifiedAllowNormalizationCandidatePass exercises the three contract
+// cases against a simulated isTableAllowed-with-normalization. We do this in
+// a sandboxed local function so the self-check is decoupled from the live
+// gate (no chicken-and-egg).
+func unqualifiedAllowNormalizationCandidatePass() bool {
+	check := func(table string, allowed []string) bool {
+		return isTableAllowedWithNormalization(table, allowed, true)
+	}
+	// (1) bare "feedback" under "public.*" must match
+	if !check("feedback", []string{"public.*"}) {
+		return false
+	}
+	// (2) bare "feedback" under {"public.users"} must NOT match
+	if check("feedback", []string{"public.users"}) {
+		return false
+	}
+	// (3) qualified "secret.keys" under "public.*" must NOT match
+	if check("secret.keys", []string{"public.*"}) {
+		return false
+	}
+	// (4) bare "feedback" under "public.feedback" must match
+	if !check("feedback", []string{"public.feedback"}) {
+		return false
+	}
+	// (5) bare "*" still allows any
+	if !check("anything", []string{"*"}) {
+		return false
+	}
+	return true
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F3 — spoofable identity warning + optional require_auth_token enforcement
+// ─────────────────────────────────────────────────────────────────────────────
+
+// requireAuthTokenOn is the runtime gate consulted by the proxy's auth
+// block. When ON, agents that present an identity but no token (or whose
+// agent definition has no auth_token configured) are rejected at startup
+// of the connection. When OFF (default), behavior is unchanged: the proxy
+// only enforces tokens for agents that have one configured.
+var requireAuthTokenOn atomic.Bool
+
+// IsRequireAuthTokenOn reports whether F3 enforcement is currently enabled.
+func IsRequireAuthTokenOn() bool {
+	return requireAuthTokenOn.Load()
+}
+
+// requireAuthTokenEnforceFn is the enforcement-decision function. Tests
+// can swap it to simulate a broken enforcer (the F3 self-check then
+// catches the broken state and falls back to warn-only). Production uses
+// requireAuthTokenEnforceImpl.
+var requireAuthTokenEnforceFn = requireAuthTokenEnforceImpl
+
+// requireAuthTokenEnforce is the public seam used by the proxy. It calls
+// through requireAuthTokenEnforceFn so the self-check sees the same
+// implementation the proxy will use.
+func requireAuthTokenEnforce(identity *AgentIdentity, agentHasToken bool, tokensMatch bool) bool {
+	return requireAuthTokenEnforceFn(identity, agentHasToken, tokensMatch)
+}
+
+// requireAuthTokenEnforceImpl is the production decision. Returns true if
+// the connection should be REJECTED (closed/fail-safe) under
+// require_auth_token=true. The function captures the spec: if F3
+// enforcement is off, never reject from this path (the proxy's existing
+// per-agent token check still runs separately).
+//
+//   - identity == nil: not our path; defer to existing unidentified policy.
+//   - identity != nil but token missing: reject.
+//   - identity has agent with no auth_token configured: reject (spoofable).
+//   - identity matches an agent with token configured and tokens differ:
+//     reject (this is also caught by the existing per-agent check; we
+//     duplicate it here so the self-check sees an enforcement signal).
+func requireAuthTokenEnforceImpl(identity *AgentIdentity, agentHasToken bool, tokensMatch bool) bool {
+	if !requireAuthTokenOn.Load() {
+		return false
+	}
+	if identity == nil {
+		return false
+	}
+	if identity.Token == "" {
+		return true
+	}
+	if !agentHasToken {
+		// Identity carries a token but the policy file has no token for
+		// this agent — we can't verify, treat as spoofable.
+		return true
+	}
+	if !tokensMatch {
+		return true
+	}
+	return false
+}
+
+// InitRequireAuthTokenGuard runs the F3 self-check. If the env var
+// FW_REQUIRE_AUTH_TOKEN is "true" the operator is asking for enforce mode.
+// We then verify the enforcement decision function actually rejects a
+// known-tokenless identity. If the check disagrees, we fall back to
+// warn-only (turn the gate OFF) with a logged WARNING. The startup warning
+// itself (count of tokenless agents) is always emitted by
+// LogIdentitySpoofWarning, regardless of this gate.
+func InitRequireAuthTokenGuard() {
+	want := strings.ToLower(strings.TrimSpace(os.Getenv("FW_REQUIRE_AUTH_TOKEN"))) == "true"
+	if !want {
+		requireAuthTokenOn.Store(false)
+		return
+	}
+	// Tentatively enable, then probe the enforcement function.
+	requireAuthTokenOn.Store(true)
+	if !requireAuthTokenSelfCheckPass() {
+		requireAuthTokenOn.Store(false)
+		log.Printf("⚠️  F3 self-check FAILED: require_auth_token enforcement could not be verified " +
+			"(known-tokenless identity was not rejected by the enforcement check). " +
+			"Falling back to WARN-ONLY mode so a buggy enforcer does not give a false sense of " +
+			"security. Set auth_token on every agent and investigate before re-enabling.")
+		return
+	}
+	log.Printf("🔐 F3 guard active: require_auth_token=true — agents without a verified token will be REJECTED.")
+}
+
+// requireAuthTokenSelfCheckPass verifies the enforcement function rejects
+// the obvious failure cases. Run only when require_auth_token is requested.
+func requireAuthTokenSelfCheckPass() bool {
+	// (a) tokenless identity must be rejected
+	tokenless := &AgentIdentity{AgentID: "selfcheck", Token: ""}
+	if !requireAuthTokenEnforce(tokenless, false, false) {
+		return false
+	}
+	// (b) identity with token but agent has no token configured: rejected
+	withToken := &AgentIdentity{AgentID: "selfcheck", Token: "x"}
+	if !requireAuthTokenEnforce(withToken, false, false) {
+		return false
+	}
+	// (c) identity with matching token must NOT be rejected
+	if requireAuthTokenEnforce(withToken, true, true) {
+		return false
+	}
+	// (d) gate off → never reject
+	requireAuthTokenOn.Store(false)
+	if requireAuthTokenEnforce(tokenless, false, false) {
+		// restore and fail
+		requireAuthTokenOn.Store(true)
+		return false
+	}
+	requireAuthTokenOn.Store(true)
+	return true
+}
+
+// LogIdentitySpoofWarning emits a single, loud startup warning if any agent
+// in the policy config has no auth_token set. The warning is always
+// printed (independent of the require_auth_token gate). Returns true if a
+// warning was emitted (used by tests).
+func LogIdentitySpoofWarning(cfg *PolicyConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	tokenless := make([]string, 0, len(cfg.Agents))
+	for id, ap := range cfg.Agents {
+		if strings.TrimSpace(ap.AuthToken) == "" {
+			tokenless = append(tokenless, id)
+		}
+	}
+	if len(tokenless) == 0 {
+		return false
+	}
+	log.Printf("⚠️  IDENTITY SPOOFING WARNING: %d agent(s) have NO auth_token configured: %s. "+
+		"Agent identity is derived from PostgreSQL application_name, which is fully spoofable. "+
+		"Without an auth_token, any client can impersonate these agent IDs and inherit their "+
+		"mission permissions. Set 'auth_token: <secret>' under each agent in policies.yaml, then "+
+		"have the agent send 'agent:<id>:mission:<m>:token:<secret>' as application_name. "+
+		"To make tokenless agents fail-closed, set FW_REQUIRE_AUTH_TOKEN=true.",
+		len(tokenless), strings.Join(tokenless, ", "))
+	return true
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F9 — DB-port isolation startup self-probe (warn-only, non-fatal)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// dbIsolationProbeResult captures what the probe observed. Returned for
+// tests; the production path only logs.
+type dbIsolationProbeResult struct {
+	Disabled    bool   // probe was disabled by config — nothing was tried
+	ProbeError  string // probe itself errored (DNS, etc) — non-fatal
+	Address     string // upstream address that was probed
+	Reachable   bool   // TCP-dial from the proxy host succeeded
+	DurationMs  int64  // wall-clock for the dial attempt
+}
+
+// dbIsolationDialer is overridable for tests so they don't depend on real
+// network listeners. Production uses net.DialTimeout.
+var dbIsolationDialer = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout(network, addr, timeout)
+}
+
+// nowFunc is overridable for tests of the F9 probe; production uses
+// time.Now. We keep it package-local so the rest of the codebase isn't
+// affected.
+var nowFunc = time.Now
+
+// RunDBIsolationProbe performs a best-effort TCP-dial against the upstream
+// Postgres address from the proxy host. It is non-fatal: a probe error
+// (DNS resolution failure, etc) is logged as a WARNING and the proxy
+// continues. The probe never blocks startup beyond its dial timeout.
+//
+// Behavior matrix:
+//   db_isolation_check=false       → skip silently, return Disabled=true
+//   reachable & probe ok           → loud WARN: DB port directly reachable
+//                                    from proxy host, isolation NOT proven
+//   unreachable & probe ok         → INFO: DB port not reachable from proxy
+//                                    host (good signal, not a guarantee)
+//   probe errored                  → WARN: probe could not run, continue
+func RunDBIsolationProbe(upstreamAddr string) dbIsolationProbeResult {
+	if strings.ToLower(strings.TrimSpace(os.Getenv("FW_DB_ISOLATION_CHECK"))) == "false" {
+		log.Printf("F9 DB-port isolation probe DISABLED via FW_DB_ISOLATION_CHECK=false. " +
+			"Operators must verify externally that agents cannot reach the upstream Postgres " +
+			"port directly; FaultWall enforces SQL only via the proxy.")
+		return dbIsolationProbeResult{Disabled: true, Address: upstreamAddr}
+	}
+
+	res := dbIsolationProbeResult{Address: upstreamAddr}
+	if upstreamAddr == "" {
+		log.Printf("⚠️  F9 DB-port isolation probe SKIPPED: no upstream address configured. " +
+			"This is a hard-isolation REQUIREMENT regardless: agents must only reach the proxy, " +
+			"not the database port directly.")
+		res.ProbeError = "no upstream address"
+		return res
+	}
+
+	start := nowFunc()
+	conn, err := dbIsolationDialer("tcp", upstreamAddr, 2*time.Second)
+	res.DurationMs = nowFunc().Sub(start).Milliseconds()
+	if err != nil {
+		// Distinguish a "connection refused" (good — port not reachable)
+		// from a probe-itself-error (DNS, permission, timeout). Both are
+		// non-fatal; we just log differently so the operator gets the
+		// right signal.
+		errStr := err.Error()
+		if strings.Contains(errStr, "refused") {
+			res.Reachable = false
+			log.Printf("F9 DB-port isolation probe: upstream %s NOT reachable from proxy host (connection refused). "+
+				"This is a *positive* local signal but NOT proof of network isolation — agents on other hosts "+
+				"or in other namespaces may still have direct access. DB-port isolation is a HARD REQUIREMENT: "+
+				"FaultWall enforces SQL only via the proxy; if agents can reach the DB port directly, the "+
+				"entire security promise is void. Verify network policy / security groups / firewall rules.",
+				upstreamAddr)
+			return res
+		}
+		// Probe-itself-error: must NOT crash the proxy.
+		res.ProbeError = errStr
+		log.Printf("⚠️  F9 DB-port isolation probe could not run for %s: %v. "+
+			"Continuing startup — this check is best-effort and non-fatal. DB-port isolation remains a "+
+			"HARD REQUIREMENT: agents must only be able to reach the proxy listener, not the upstream "+
+			"database port directly. Verify network policy / security groups / firewall rules manually.",
+			upstreamAddr, err)
+		return res
+	}
+	conn.Close()
+	res.Reachable = true
+	log.Printf("⚠️  F9 DB-port isolation probe: upstream %s IS DIRECTLY REACHABLE from the proxy host. "+
+		"This is best-effort topology info: it CONFIRMS the proxy can reach the DB (good), but it does "+
+		"NOT prove that other hosts/agents are blocked. DB-port isolation is a HARD REQUIREMENT — if "+
+		"agents can reach %s without going through the proxy, all SQL-level enforcement is bypassed and "+
+		"PII is exposed. Verify network policy / security groups / firewall rules so that ONLY the "+
+		"FaultWall proxy can reach the upstream Postgres port.",
+		upstreamAddr, upstreamAddr)
+	return res
+}

--- a/guards_test.go
+++ b/guards_test.go
@@ -1,0 +1,419 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureLog redirects the standard logger output for the duration of fn so
+// we can assert on the WARNING text. The default *log.Logger is the one our
+// production code uses (log.Printf), so this captures it correctly.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	oldOut := log.Writer()
+	oldFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(oldOut)
+		log.SetFlags(oldFlags)
+	}()
+	fn()
+	return buf.String()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F2 — unqualified-name allow-path normalization
+// ─────────────────────────────────────────────────────────────────────────────
+
+// (a) Healthy path: with the guard ON, bare "feedback" is allowed under
+// "public.*" — the original bug.
+func TestF2_HealthyPath_BareFeedbackAllowedUnderPublicStar(t *testing.T) {
+	prev := IsUnqualifiedAllowNormalizationOn()
+	defer setUnqualifiedAllowNormalization(prev)
+	setUnqualifiedAllowNormalization(true)
+
+	if !isTableAllowed("feedback", []string{"public.*"}) {
+		t.Errorf("F2 ON: bare unqualified \"feedback\" must match allow=[public.*], got false")
+	}
+}
+
+// (b) Fallback path: with the guard OFF (self-check failed), the prior
+// behavior is preserved — bare "feedback" is NOT allowed under "public.*".
+// This is fail-safe: deny rather than silently flip to a possibly-broken
+// allow.
+func TestF2_FallbackPath_BareFeedbackBlockedUnderPublicStar(t *testing.T) {
+	prev := IsUnqualifiedAllowNormalizationOn()
+	defer setUnqualifiedAllowNormalization(prev)
+	setUnqualifiedAllowNormalization(false)
+
+	if isTableAllowed("feedback", []string{"public.*"}) {
+		t.Errorf("F2 OFF: must preserve pre-fix behavior — bare \"feedback\" should NOT match allow=[public.*]")
+	}
+}
+
+// (c) Outside-allow-list table is still denied even with the guard ON.
+// This is the regression-protection check the prompt called out: a table
+// not in the allow list must remain blocked.
+func TestF2_HealthyPath_TableOutsideAllowListStillDenied(t *testing.T) {
+	prev := IsUnqualifiedAllowNormalizationOn()
+	defer setUnqualifiedAllowNormalization(prev)
+	setUnqualifiedAllowNormalization(true)
+
+	// allow only public.users — bare "feedback" must NOT match
+	if isTableAllowed("feedback", []string{"public.users"}) {
+		t.Error("F2 ON: bare \"feedback\" must NOT match allow=[public.users]")
+	}
+	// schema-qualified table outside the allowed schema must still be blocked
+	if isTableAllowed("secret.keys", []string{"public.*"}) {
+		t.Error("F2 ON: \"secret.keys\" must NOT match allow=[public.*]")
+	}
+}
+
+// (d) Block path is unaffected by the F2 guard. isTableBlocked must still
+// flag a blocked table whether the guard is on or off — the fix is only in
+// the ALLOW path.
+func TestF2_BlockPathUnchanged(t *testing.T) {
+	for _, on := range []bool{true, false} {
+		prev := IsUnqualifiedAllowNormalizationOn()
+		setUnqualifiedAllowNormalization(on)
+		if !isTableBlocked("public.users", []string{"public.users"}) {
+			t.Errorf("isTableBlocked must remain true (guard=%v)", on)
+		}
+		if !isTableBlocked("users", []string{"public.users"}) {
+			t.Errorf("isTableBlocked schema-agnostic match must still fire (guard=%v)", on)
+		}
+		if isTableBlocked("public.allowed", []string{"public.users"}) {
+			t.Errorf("isTableBlocked must not over-match (guard=%v)", on)
+		}
+		setUnqualifiedAllowNormalization(prev)
+	}
+}
+
+// (e) Self-check engages the guard on the canonical happy case.
+func TestF2_SelfCheckEngagesGuard(t *testing.T) {
+	prev := IsUnqualifiedAllowNormalizationOn()
+	defer setUnqualifiedAllowNormalization(prev)
+	setUnqualifiedAllowNormalization(false)
+
+	out := captureLog(t, func() { InitUnqualifiedAllowGuard() })
+	if !IsUnqualifiedAllowNormalizationOn() {
+		t.Fatalf("self-check should pass on the canonical case — guard expected ON. log: %s", out)
+	}
+	if !strings.Contains(out, "F2 guard active") {
+		t.Errorf("expected F2 guard-active log, got: %s", out)
+	}
+}
+
+// (f) Self-check failure path: simulate by swapping the default schema to a
+// value that breaks expectation (1) of the self-check. The guard must stay
+// OFF and a clear WARNING must be logged. Restores the original schema.
+func TestF2_SelfCheckFailureFallsBack(t *testing.T) {
+	prevSchema := defaultSchemaForAllowMatch
+	prevGate := IsUnqualifiedAllowNormalizationOn()
+	defer func() {
+		defaultSchemaForAllowMatch = prevSchema
+		setUnqualifiedAllowNormalization(prevGate)
+	}()
+
+	// Force the self-check to fail by pointing at a schema that won't
+	// match "public.*" — bare "feedback" → "wrongschema.feedback" doesn't
+	// hit the public.* prefix, so check (1) returns false.
+	defaultSchemaForAllowMatch = "wrongschema"
+	setUnqualifiedAllowNormalization(true) // start ON to prove fallback flips it OFF
+
+	out := captureLog(t, func() { InitUnqualifiedAllowGuard() })
+	if IsUnqualifiedAllowNormalizationOn() {
+		t.Fatalf("self-check should fail — guard expected OFF. log: %s", out)
+	}
+	if !strings.Contains(out, "F2 self-check FAILED") {
+		t.Errorf("expected F2 self-check FAILED warning, got: %s", out)
+	}
+}
+
+// (g) End-to-end through CheckQuery: with F2 ON, an agent that emits an
+// unqualified "FROM feedback" under a public.* mission must NOT get
+// table_not_in_mission.
+func TestF2_EndToEnd_CheckQueryUnqualifiedUnderPublicStar(t *testing.T) {
+	prev := IsUnqualifiedAllowNormalizationOn()
+	defer setUnqualifiedAllowNormalization(prev)
+	setUnqualifiedAllowNormalization(true)
+
+	pe := &PolicyEngine{
+		config: &PolicyConfig{
+			DefaultPolicy: "allow",
+			Agents: map[string]AgentPolicy{
+				"orm-agent": {
+					AuthToken: "tok",
+					Missions: map[string]MissionPolicy{
+						"read": {Tables: []string{"public.*"}},
+					},
+				},
+			},
+			Unidentified: UnidentifiedPolicy{Policy: "deny"},
+		},
+		enforcement: "enforce",
+	}
+	id := &AgentIdentity{AgentID: "orm-agent", MissionID: "read", Token: "tok"}
+	if v := pe.CheckQuery(id, "SELECT * FROM feedback", 0); v != nil && v.Reason == "table_not_in_mission" {
+		t.Errorf("F2 ON: unqualified FROM feedback under public.* must not be table_not_in_mission, got %+v", v)
+	}
+}
+
+// And with F2 OFF, the prior over-blocking behavior is preserved.
+func TestF2_EndToEnd_FallbackOverblocksLikeBefore(t *testing.T) {
+	prev := IsUnqualifiedAllowNormalizationOn()
+	defer setUnqualifiedAllowNormalization(prev)
+	setUnqualifiedAllowNormalization(false)
+
+	pe := &PolicyEngine{
+		config: &PolicyConfig{
+			DefaultPolicy: "allow",
+			Agents: map[string]AgentPolicy{
+				"orm-agent": {
+					AuthToken: "tok",
+					Missions: map[string]MissionPolicy{
+						"read": {Tables: []string{"public.*"}},
+					},
+				},
+			},
+			Unidentified: UnidentifiedPolicy{Policy: "deny"},
+		},
+		enforcement: "enforce",
+	}
+	id := &AgentIdentity{AgentID: "orm-agent", MissionID: "read", Token: "tok"}
+	v := pe.CheckQuery(id, "SELECT * FROM feedback", 0)
+	if v == nil || v.Reason != "table_not_in_mission" {
+		t.Errorf("F2 OFF: must reproduce the pre-fix table_not_in_mission for unqualified ORM names, got %+v", v)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F3 — spoofable identity warning + optional enforcement
+// ─────────────────────────────────────────────────────────────────────────────
+
+// (a) Warning emitted when at least one agent is tokenless.
+func TestF3_WarningWhenTokenlessAgentExists(t *testing.T) {
+	cfg := &PolicyConfig{
+		Agents: map[string]AgentPolicy{
+			"good": {AuthToken: "tok"},
+			"bad":  {}, // no token → spoofable
+		},
+	}
+	out := captureLog(t, func() { LogIdentitySpoofWarning(cfg) })
+	if !strings.Contains(out, "IDENTITY SPOOFING WARNING") {
+		t.Errorf("expected spoofing warning when tokenless agent exists, got: %s", out)
+	}
+	if !strings.Contains(out, "bad") {
+		t.Errorf("warning should name the tokenless agent, got: %s", out)
+	}
+	if strings.Count(out, "IDENTITY SPOOFING WARNING") != 1 {
+		t.Errorf("warning should be emitted exactly once (no per-connection spam), got: %s", out)
+	}
+}
+
+// (b) No warning when every agent has a token.
+func TestF3_NoWarningWhenAllTokensSet(t *testing.T) {
+	cfg := &PolicyConfig{
+		Agents: map[string]AgentPolicy{
+			"a": {AuthToken: "tok-a"},
+			"b": {AuthToken: "tok-b"},
+		},
+	}
+	out := captureLog(t, func() { LogIdentitySpoofWarning(cfg) })
+	if strings.Contains(out, "IDENTITY SPOOFING WARNING") {
+		t.Errorf("no warning expected when all agents have tokens, got: %s", out)
+	}
+}
+
+// (c) Healthy enforcement: require_auth_token=true blocks tokenless
+// identity. We exercise the enforcement-decision function directly so we
+// don't need to spin up a full proxy.
+func TestF3_RequireAuthToken_BlocksTokenlessAgent(t *testing.T) {
+	prev := IsRequireAuthTokenOn()
+	defer requireAuthTokenOn.Store(prev)
+	requireAuthTokenOn.Store(true)
+
+	tokenless := &AgentIdentity{AgentID: "x", Token: ""}
+	if !requireAuthTokenEnforce(tokenless, false, false) {
+		t.Error("require_auth_token ON: tokenless identity must be rejected")
+	}
+}
+
+// (d) Self-check failure path: simulate by stubbing the gate so that the
+// enforcement function rejects nothing (a "broken enforcer"). The guard
+// must fall back to warn-only and the operator gets a clear WARNING.
+//
+// We model the broken enforcer by setting FW_REQUIRE_AUTH_TOKEN=true but
+// then poisoning the gate — emulated here by having the self-check observe
+// a stubbed state. The cleanest way is to give the self-check a function
+// hook for tests (or alternatively, swap the env var path).
+func TestF3_SelfCheckFailureFallsBackToWarnOnly(t *testing.T) {
+	prevEnv, hadEnv := os.LookupEnv("FW_REQUIRE_AUTH_TOKEN")
+	defer func() {
+		if hadEnv {
+			os.Setenv("FW_REQUIRE_AUTH_TOKEN", prevEnv)
+		} else {
+			os.Unsetenv("FW_REQUIRE_AUTH_TOKEN")
+		}
+		requireAuthTokenOn.Store(false)
+	}()
+	os.Setenv("FW_REQUIRE_AUTH_TOKEN", "true")
+
+	// Inject a broken enforcer for the duration of the test by overriding
+	// the package-level decision function. The self-check then observes
+	// "tokenless identity not rejected" and must fall back.
+	prevDecision := requireAuthTokenEnforceFn
+	defer func() { requireAuthTokenEnforceFn = prevDecision }()
+	requireAuthTokenEnforceFn = func(id *AgentIdentity, hasToken, match bool) bool {
+		// Broken: never reject anything.
+		return false
+	}
+
+	out := captureLog(t, func() { InitRequireAuthTokenGuard() })
+	if IsRequireAuthTokenOn() {
+		t.Fatalf("broken enforcer self-check must DISABLE require_auth_token. log: %s", out)
+	}
+	if !strings.Contains(out, "F3 self-check FAILED") {
+		t.Errorf("expected F3 self-check FAILED warning, got: %s", out)
+	}
+}
+
+// (e) Self-check pass path: env on + real enforcer → guard activates.
+func TestF3_SelfCheckPassEnablesEnforcement(t *testing.T) {
+	prevEnv, hadEnv := os.LookupEnv("FW_REQUIRE_AUTH_TOKEN")
+	defer func() {
+		if hadEnv {
+			os.Setenv("FW_REQUIRE_AUTH_TOKEN", prevEnv)
+		} else {
+			os.Unsetenv("FW_REQUIRE_AUTH_TOKEN")
+		}
+		requireAuthTokenOn.Store(false)
+	}()
+	os.Setenv("FW_REQUIRE_AUTH_TOKEN", "true")
+
+	out := captureLog(t, func() { InitRequireAuthTokenGuard() })
+	if !IsRequireAuthTokenOn() {
+		t.Fatalf("self-check should pass and enable F3 enforcement. log: %s", out)
+	}
+	if !strings.Contains(out, "F3 guard active") {
+		t.Errorf("expected F3 guard-active log, got: %s", out)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F9 — DB-port isolation startup self-probe
+// ─────────────────────────────────────────────────────────────────────────────
+
+// (a) Probe runs and reports REACHABLE against a real test listener. The
+// loud isolation warning must fire. We stand up a localhost listener so we
+// don't depend on any external host.
+func TestF9_ProbeReachableAgainstTestListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("test setup: failed to listen: %v", err)
+	}
+	defer ln.Close()
+	addr := ln.Addr().String()
+
+	out := captureLog(t, func() {
+		res := RunDBIsolationProbe(addr)
+		if !res.Reachable {
+			t.Errorf("expected reachable=true, got %+v", res)
+		}
+	})
+	if !strings.Contains(out, "DIRECTLY REACHABLE") {
+		t.Errorf("expected DIRECTLY REACHABLE warning, got: %s", out)
+	}
+	if !strings.Contains(out, "HARD REQUIREMENT") {
+		t.Errorf("expected HARD REQUIREMENT in warning, got: %s", out)
+	}
+}
+
+// (b) Probe runs against an unreachable port. Connection-refused is
+// reported as a positive local signal (not reachable from this host) but
+// still flags isolation as a hard requirement.
+func TestF9_ProbeUnreachablePort(t *testing.T) {
+	// Bind and immediately close to grab a port that's then refused.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("test setup: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	out := captureLog(t, func() {
+		res := RunDBIsolationProbe(addr)
+		if res.Reachable {
+			t.Errorf("expected reachable=false for closed port, got %+v", res)
+		}
+		if res.ProbeError != "" {
+			t.Errorf("connection refused should not be a probe error, got: %q", res.ProbeError)
+		}
+	})
+	if !strings.Contains(out, "NOT reachable") {
+		t.Errorf("expected NOT reachable log, got: %s", out)
+	}
+}
+
+// (c) Probe failure (probe-itself errors) does NOT crash and DOES log a
+// warning. We force this by overriding the dialer with one that returns a
+// non-refused error.
+func TestF9_ProbeErrorDoesNotCrash(t *testing.T) {
+	prev := dbIsolationDialer
+	defer func() { dbIsolationDialer = prev }()
+	dbIsolationDialer = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		return nil, errors.New("simulated DNS failure")
+	}
+
+	out := captureLog(t, func() {
+		// Must not panic.
+		res := RunDBIsolationProbe("does-not-resolve.invalid:5432")
+		if res.ProbeError == "" {
+			t.Error("expected ProbeError to be set on dialer failure")
+		}
+		if res.Reachable {
+			t.Error("dialer failure must not flip Reachable=true")
+		}
+	})
+	if !strings.Contains(out, "could not run") {
+		t.Errorf("expected probe-could-not-run warning, got: %s", out)
+	}
+	if !strings.Contains(out, "non-fatal") {
+		t.Errorf("warning should describe probe as non-fatal, got: %s", out)
+	}
+}
+
+// (d) Disabled by config: the probe is skipped and a single line is
+// logged so the operator sees that they turned it off intentionally.
+func TestF9_DisabledByConfig(t *testing.T) {
+	prev, had := os.LookupEnv("FW_DB_ISOLATION_CHECK")
+	defer func() {
+		if had {
+			os.Setenv("FW_DB_ISOLATION_CHECK", prev)
+		} else {
+			os.Unsetenv("FW_DB_ISOLATION_CHECK")
+		}
+	}()
+	os.Setenv("FW_DB_ISOLATION_CHECK", "false")
+
+	out := captureLog(t, func() {
+		res := RunDBIsolationProbe("127.0.0.1:1") // would otherwise be refused
+		if !res.Disabled {
+			t.Errorf("expected Disabled=true when FW_DB_ISOLATION_CHECK=false, got %+v", res)
+		}
+		if res.Reachable {
+			t.Error("must not run dial when disabled")
+		}
+	})
+	if !strings.Contains(out, "DISABLED") {
+		t.Errorf("expected disabled-log, got: %s", out)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -191,6 +191,36 @@ func main() {
 		LogIdentitySpoofWarning(policyEngine.GetConfig()) // F3 (always)
 		InitRequireAuthTokenGuard()                       // F3 (optional enforce)
 		RunDBIsolationProbe(proxyUpstream)                // F9 (shipped: TCP probe)
+		InitBypassDetectionGuard()                        // REAL-F9 (runtime bypass detection)
+
+		// REAL-F9: poll pg_stat_activity and warn on agent-like sessions
+		// the proxy did not originate. Uses a small monitoring DB pool
+		// (same DSN strategy as the QWM state sampler — DATABASE_URL
+		// preferred, falls back to upstream-derived). Observe-only.
+		if IsBypassDetectionOn() {
+			if dsn, ok := monitoringDSNFromUpstream(proxyUpstream); ok {
+				if mdb, err := openMonitoringDB(dsn); err == nil {
+					if perr := mdb.Ping(); perr == nil {
+						interval := 30 * time.Second
+						if v := os.Getenv("FW_BYPASS_DETECTION_INTERVAL"); v != "" {
+							if d, err := time.ParseDuration(v); err == nil && d > 0 {
+								interval = d
+							}
+						}
+						bd := NewBypassDetector(proxyBackendRegistry, NewDBBypassRowSource(mdb), interval)
+						bd.Start()
+						log.Printf("🔍 REAL-F9 bypass detector running every %s (observe-only)", interval)
+					} else {
+						mdb.Close()
+						log.Printf("⚠️  REAL-F9 bypass detector: monitoring DB ping failed: %v — detection skipped", perr)
+					}
+				} else {
+					log.Printf("⚠️  REAL-F9 bypass detector: monitoring DB open failed: %v — detection skipped", err)
+				}
+			} else {
+				log.Printf("⚠️  REAL-F9 bypass detector: no monitoring DSN — detection skipped")
+			}
+		}
 
 		// Start proxy in a goroutine so we can also run the API server
 		go runProxy(proxyListen, proxyUpstream, policyEngine, tlsCert, tlsKey, upstreamTLS, upstreamTLSSkipVerify)

--- a/main.go
+++ b/main.go
@@ -181,6 +181,16 @@ func main() {
 			log.Printf("📡 Control-plane telemetry enabled → %s (metadata only)", cpCfg.URL)
 		}
 
+		// Self-disabling feature guards (see guards.go). Each guard runs a
+		// startup self-check; if the check fails, the new behavior turns
+		// itself off and the proxy falls back to the prior safe path. We
+		// run these BEFORE starting the proxy so the gates are settled
+		// before any connection is accepted.
+		InitUnqualifiedAllowGuard()                    // F2
+		LogIdentitySpoofWarning(policyEngine.GetConfig()) // F3 (always)
+		InitRequireAuthTokenGuard()                    // F3 (optional enforce)
+		RunDBIsolationProbe(proxyUpstream)             // F9
+
 		// Start proxy in a goroutine so we can also run the API server
 		go runProxy(proxyListen, proxyUpstream, policyEngine, tlsCert, tlsKey, upstreamTLS, upstreamTLSSkipVerify)
 

--- a/main.go
+++ b/main.go
@@ -186,10 +186,11 @@ func main() {
 		// itself off and the proxy falls back to the prior safe path. We
 		// run these BEFORE starting the proxy so the gates are settled
 		// before any connection is accepted.
-		InitUnqualifiedAllowGuard()                    // F2
+		InitUnqualifiedAllowGuard()                       // F2 (shipped: public-only)
+		InitSearchPathAwareAllowGuard()                   // REAL-F2 (per-connection search_path)
 		LogIdentitySpoofWarning(policyEngine.GetConfig()) // F3 (always)
-		InitRequireAuthTokenGuard()                    // F3 (optional enforce)
-		RunDBIsolationProbe(proxyUpstream)             // F9
+		InitRequireAuthTokenGuard()                       // F3 (optional enforce)
+		RunDBIsolationProbe(proxyUpstream)                // F9 (shipped: TCP probe)
 
 		// Start proxy in a goroutine so we can also run the API server
 		go runProxy(proxyListen, proxyUpstream, policyEngine, tlsCert, tlsKey, upstreamTLS, upstreamTLSSkipVerify)

--- a/policy.go
+++ b/policy.go
@@ -498,18 +498,48 @@ func checkConditions(conditions []string, operation string, query string, identi
 	return nil
 }
 
+// QueryContext carries per-connection state into a CheckQuery call.
+//
+// SearchPath, when non-nil, is the ordered list of schemas the agent has
+// most recently set on this connection (see searchpath.go). It is used by
+// the REAL-F2 path to (a) resolve unqualified ALLOW matches against the
+// agent's actual search_path and (b) catch unqualified BLOCKED matches
+// across every schema the agent could resolve into. nil/empty is
+// equivalent to the pre-REAL-F2 behavior.
+type QueryContext struct {
+	SearchPath []string
+}
+
 // CheckQuery evaluates a query against the loaded policies.
 // Returns nil if allowed, a PolicyViolation if blocked/flagged.
 // CheckQuery parses query and evaluates it against the policy.
 // If the caller already has a *ParsedQuery (e.g. from a prior parse on the same
 // query), use CheckQueryWithParsed to avoid the extra CGO round-trip.
 func (pe *PolicyEngine) CheckQuery(identity *AgentIdentity, query string, pid int) *PolicyViolation {
-	return pe.CheckQueryWithParsed(identity, ParseQuery(query), query, pid)
+	return pe.CheckQueryWithContext(identity, ParseQuery(query), query, pid, nil)
 }
 
 // CheckQueryWithParsed is CheckQuery with a pre-parsed *ParsedQuery.
 // parsed.Fingerprint must already be set (ParseQuery sets it automatically).
 func (pe *PolicyEngine) CheckQueryWithParsed(identity *AgentIdentity, parsed *ParsedQuery, query string, pid int) *PolicyViolation {
+	return pe.CheckQueryWithContext(identity, parsed, query, pid, nil)
+}
+
+// CheckQueryWithContext is the search-path-aware variant of
+// CheckQueryWithParsed. ctx may be nil (equivalent to no per-connection
+// state). The schema-context is consulted by isTableAllowedWithContext /
+// isTableBlockedWithContext only when the REAL-F2 guard
+// (IsSearchPathAwareAllowOn) is engaged, so a nil ctx or a disabled gate
+// preserves the shipped behavior.
+func (pe *PolicyEngine) CheckQueryWithContext(identity *AgentIdentity, parsed *ParsedQuery, query string, pid int, ctx *QueryContext) *PolicyViolation {
+	var searchPath []string
+	if ctx != nil {
+		searchPath = ctx.SearchPath
+	}
+	return pe.checkQueryImpl(identity, parsed, query, pid, searchPath)
+}
+
+func (pe *PolicyEngine) checkQueryImpl(identity *AgentIdentity, parsed *ParsedQuery, query string, pid int, searchPath []string) *PolicyViolation {
 	pe.mu.RLock()
 	cfg := pe.config
 	pe.mu.RUnlock()
@@ -652,7 +682,7 @@ func (pe *PolicyEngine) CheckQueryWithParsed(identity *AgentIdentity, parsed *Pa
 
 		// Check blocked tables for unidentified connections
 		for _, table := range tables {
-			if isTableBlocked(table, cfg.Unidentified.BlockedTables) {
+			if isTableBlockedWithContext(table, cfg.Unidentified.BlockedTables, searchPath) {
 				return &PolicyViolation{
 					AgentID:   "unidentified",
 					Query:     truncateQuery(query),
@@ -798,7 +828,7 @@ func (pe *PolicyEngine) CheckQueryWithParsed(identity *AgentIdentity, parsed *Pa
 
 	// Check blocked tables (global for agent — applies regardless of profile)
 	for _, table := range tables {
-		if isTableBlocked(table, agentPolicy.BlockedTables) {
+		if isTableBlockedWithContext(table, agentPolicy.BlockedTables, searchPath) {
 			return &PolicyViolation{
 				AgentID:   identity.AgentID,
 				MissionID: identity.MissionID,
@@ -894,7 +924,7 @@ func (pe *PolicyEngine) CheckQueryWithParsed(identity *AgentIdentity, parsed *Pa
 			// Check tables against mission allowed list
 			if len(missionPolicy.Tables) > 0 {
 				for _, table := range tables {
-					if !isTableAllowed(table, missionPolicy.Tables) {
+					if !isTableAllowedWithContext(table, missionPolicy.Tables, IsUnqualifiedAllowNormalizationOn(), searchPath) {
 						return &PolicyViolation{
 							AgentID:   identity.AgentID,
 							MissionID: identity.MissionID,
@@ -1388,42 +1418,122 @@ func isTableAllowed(table string, allowedList []string) bool {
 // by isTableAllowed (using the live gate) and by the F2 self-check (which
 // passes normalize=true to verify the candidate behavior in isolation).
 func isTableAllowedWithNormalization(table string, allowedList []string, normalize bool) bool {
+	return isTableAllowedWithContext(table, allowedList, normalize, nil)
+}
+
+// isTableAllowedWithContext is the search-path-aware ALLOW matcher. The
+// `searchPath` parameter is the connection's current SET search_path, in
+// order, lowercased. When non-empty AND the REAL-F2 guard is on, an
+// unqualified table reference is tried against EACH schema in the path:
+// for each `<schema>.<table>` candidate, the function returns true on the
+// first allow match. If `searchPath` is nil/empty (or REAL-F2 is off), the
+// function falls back to the shipped public-only normalization controlled
+// by `normalize` (which mirrors `IsUnqualifiedAllowNormalizationOn()`).
+//
+// `$user` entries in the search_path are skipped because we cannot
+// expand them without querying current_user; matching falls through to
+// remaining entries.
+//
+// LOOSENS the allow path only (never tightens). The BLOCK path is the
+// concern of isTableBlockedWithContext, which is structurally separate
+// and never relies on this function.
+func isTableAllowedWithContext(table string, allowedList []string, normalize bool, searchPath []string) bool {
 	tableLower := strings.ToLower(table)
-	// F2: synthesize a schema-qualified candidate ("feedback" →
-	// "public.feedback") that the existing wildcard / exact-match branches
-	// can compare against. Only used when the table is unqualified; we
-	// never strip a schema the caller already supplied.
-	tableQualified := ""
-	if normalize && !strings.Contains(tableLower, ".") {
-		tableQualified = defaultSchemaForAllowMatch + "." + tableLower
+	unqualified := !strings.Contains(tableLower, ".")
+
+	// Build the set of qualified candidates to try against the allow list.
+	// Always include the bare lowercase name itself (preserves the
+	// schema-agnostic branch for explicit "users" allow entries).
+	candidates := []string{tableLower}
+
+	if unqualified {
+		realF2 := IsSearchPathAwareAllowOn() && len(searchPath) > 0
+		if realF2 {
+			// REAL-F2: use the connection's actual search_path
+			// EXCLUSIVELY for unqualified ALLOW resolution. We do NOT
+			// also fall through to the static default schema — that
+			// would over-allow (e.g. mission=[public.*], agent did
+			// `SET search_path TO myschema`, query `feedback` would
+			// otherwise wrongly match public.feedback even though
+			// Postgres will resolve to myschema.feedback). The
+			// search_path slice is what the agent actually told the
+			// server.
+			for _, sc := range searchPath {
+				sc = strings.ToLower(strings.TrimSpace(sc))
+				if sc == "" || sc == "$user" {
+					// Cannot resolve $user without querying the DB; skip
+					// it and fall through to the next entry, as Postgres
+					// effectively does when no role-named schema exists.
+					continue
+				}
+				candidates = append(candidates, sc+"."+tableLower)
+			}
+		} else if normalize {
+			// Shipped F2 (no search_path context): assume Postgres'
+			// factory default — `public` first.
+			candidates = append(candidates, defaultSchemaForAllowMatch+"."+tableLower)
+		}
 	}
+
 	for _, allowed := range allowedList {
 		// Mission tables use format "schema.table: [ops]" or just "schema.table"
 		allowedClean := strings.Split(allowed, ":")[0]
 		allowedClean = strings.TrimSpace(strings.ToLower(allowedClean))
-		// Bare "*" allows any table.
 		if allowedClean == "*" {
 			return true
 		}
-		// Wildcard prefix: "public.*" matches any "public.<t>".
 		if strings.HasSuffix(allowedClean, ".*") {
 			prefix := strings.TrimSuffix(allowedClean, "*")
-			if strings.HasPrefix(tableLower, prefix) {
-				return true
-			}
-			if tableQualified != "" && strings.HasPrefix(tableQualified, prefix) {
-				return true
+			for _, c := range candidates {
+				if strings.HasPrefix(c, prefix) {
+					return true
+				}
 			}
 			continue
 		}
-		if tableLower == allowedClean {
+		for _, c := range candidates {
+			if c == allowedClean {
+				return true
+			}
+		}
+		// Schema-agnostic bare-name match: allow "users" matches a
+		// referenced "public.users". Preserved from the original.
+		if unqualified && strings.HasSuffix(allowedClean, "."+tableLower) {
 			return true
 		}
-		if tableQualified != "" && tableQualified == allowedClean {
-			return true
+	}
+	return false
+}
+
+// isTableBlockedWithContext is the search-path-aware BLOCK matcher. It MUST
+// be at least as strict as isTableBlocked: an unqualified bare reference is
+// considered to potentially resolve to ANY schema in the connection's
+// current search_path, so a blocked `secret.keys` is still caught when an
+// agent did `SET search_path TO secret` and queries `keys`.
+//
+// When the REAL-F2 gate is OFF or the caller did not supply a search_path,
+// this function delegates to isTableBlocked with no behavior change. We
+// never weaken blocking: callers always get at-least-shipped enforcement.
+func isTableBlockedWithContext(table string, blockedList []string, searchPath []string) bool {
+	if isTableBlocked(table, blockedList) {
+		return true
+	}
+	// Only consider extra schema candidates for BLOCKING when the REAL-F2
+	// guard is engaged AND a search_path was supplied. This keeps the
+	// fallback path identical to the shipped behavior.
+	if !IsSearchPathAwareAllowOn() {
+		return false
+	}
+	tableLower := strings.ToLower(strings.TrimSpace(table))
+	if tableLower == "" || strings.Contains(tableLower, ".") {
+		return false
+	}
+	for _, sc := range searchPath {
+		sc = strings.ToLower(strings.TrimSpace(sc))
+		if sc == "" || sc == "$user" {
+			continue
 		}
-		// Also match without schema prefix
-		if !strings.Contains(tableLower, ".") && strings.HasSuffix(allowedClean, "."+tableLower) {
+		if isTableBlocked(sc+"."+tableLower, blockedList) {
 			return true
 		}
 	}

--- a/policy.go
+++ b/policy.go
@@ -1369,8 +1369,34 @@ func isAnyTableReferenced(target string, referenced []string) bool {
 //   - Exact match: "public.users" == "public.users"
 //   - Wildcard prefix: "public.*" matches "public.messages"; bare "*" matches all
 //   - Schema-agnostic bare-name match: allow "users" matches "public.users"
+//
+// F2 fix: when the F2 guard is on (see guards.go), an unqualified table
+// reference is also normalized to the default schema (e.g. "feedback"
+// → "public.feedback") for ALLOW matching only. The pre-fix behavior is
+// preserved when the guard is off, so a self-check failure cleanly falls
+// back to the stricter (and historically-shipped) ALLOW path.
+//
+// This function only ever LOOSENS the allow path; it must never tighten it
+// in a way that would let a previously-blocked query through. The BLOCK
+// path (isTableBlocked) is unchanged.
 func isTableAllowed(table string, allowedList []string) bool {
+	return isTableAllowedWithNormalization(table, allowedList, IsUnqualifiedAllowNormalizationOn())
+}
+
+// isTableAllowedWithNormalization is the implementation of isTableAllowed
+// parameterized on whether the F2 normalization is on. It is called both
+// by isTableAllowed (using the live gate) and by the F2 self-check (which
+// passes normalize=true to verify the candidate behavior in isolation).
+func isTableAllowedWithNormalization(table string, allowedList []string, normalize bool) bool {
 	tableLower := strings.ToLower(table)
+	// F2: synthesize a schema-qualified candidate ("feedback" →
+	// "public.feedback") that the existing wildcard / exact-match branches
+	// can compare against. Only used when the table is unqualified; we
+	// never strip a schema the caller already supplied.
+	tableQualified := ""
+	if normalize && !strings.Contains(tableLower, ".") {
+		tableQualified = defaultSchemaForAllowMatch + "." + tableLower
+	}
 	for _, allowed := range allowedList {
 		// Mission tables use format "schema.table: [ops]" or just "schema.table"
 		allowedClean := strings.Split(allowed, ":")[0]
@@ -1385,9 +1411,15 @@ func isTableAllowed(table string, allowedList []string) bool {
 			if strings.HasPrefix(tableLower, prefix) {
 				return true
 			}
+			if tableQualified != "" && strings.HasPrefix(tableQualified, prefix) {
+				return true
+			}
 			continue
 		}
 		if tableLower == allowedClean {
+			return true
+		}
+		if tableQualified != "" && tableQualified == allowedClean {
 			return true
 		}
 		// Also match without schema prefix

--- a/proxy.go
+++ b/proxy.go
@@ -381,6 +381,13 @@ func writeWireMessage(w io.Writer, msgType byte, payload []byte) error {
 func proxyQueryLoop(client, upstream net.Conn, identity *AgentIdentity, agentLabel string, pe *PolicyEngine) {
 	var clientWriteMu sync.Mutex
 
+	// REAL-F2: per-connection search_path. proxyQueryLoop is one goroutine
+	// per client connection — the right scope. We watch every Q/Parse for a
+	// `SET search_path …` (or RESET) and update this state. The policy
+	// check then sees the agent's actual current search_path, not the
+	// hard-coded "public" assumption from the shipped F2.
+	searchPath := NewSearchPathState()
+
 	// Row limit enforcement state
 	maxRows := pe.GetMaxRows(identity)
 	maxQueryTimeMs := pe.GetMaxQueryTimeMs(identity)
@@ -496,8 +503,16 @@ func proxyQueryLoop(client, upstream net.Conn, identity *AgentIdentity, agentLab
 		// Simple query protocol: type 'Q'
 		if msgType == 'Q' && len(payload) > 1 {
 			query := string(payload[:len(payload)-1])
+			// REAL-F2: track per-connection search_path BEFORE the policy
+			// check. A `SET search_path …` is a no-op for tables/functions
+			// blocking but updates the state used to resolve unqualified
+			// names in subsequent queries.
+			if IsSearchPathStatement(query) {
+				searchPath.ApplySearchPathStatement(query)
+			}
+			ctx := &QueryContext{SearchPath: searchPath.Schemas()}
 			decisionStart := time.Now()
-			violation, pq := safeCheckQuery(pe, identity, query)
+			violation, pq := safeCheckQueryWithContext(pe, identity, query, ctx)
 			decisionLatencyMs := float64(time.Since(decisionStart).Microseconds()) / 1000.0
 
 			// Track this query in the agent tracker
@@ -542,8 +557,12 @@ func proxyQueryLoop(client, upstream net.Conn, identity *AgentIdentity, agentLab
 			stmtName, query := extractParseMessage(payload)
 
 			if query != "" {
+				if IsSearchPathStatement(query) {
+					searchPath.ApplySearchPathStatement(query)
+				}
+				ctx := &QueryContext{SearchPath: searchPath.Schemas()}
 				decisionStart := time.Now()
-				violation, pq := safeCheckQuery(pe, identity, query)
+				violation, pq := safeCheckQueryWithContext(pe, identity, query, ctx)
 				decisionLatencyMs := float64(time.Since(decisionStart).Microseconds()) / 1000.0
 
 				// Track this query in the agent tracker
@@ -826,6 +845,13 @@ func sendStartupError(client net.Conn, msg string) {
 // panic recovery (fail-open). Returns both the violation and the *ParsedQuery
 // so callers can reuse the parsed result without a second CGO round-trip.
 func safeCheckQuery(pe *PolicyEngine, identity *AgentIdentity, query string) (violation *PolicyViolation, parsed *ParsedQuery) {
+	return safeCheckQueryWithContext(pe, identity, query, nil)
+}
+
+// safeCheckQueryWithContext is safeCheckQuery with a per-connection
+// QueryContext (currently the search_path snapshot). The proxy hot path
+// uses this; other callers can pass nil.
+func safeCheckQueryWithContext(pe *PolicyEngine, identity *AgentIdentity, query string, ctx *QueryContext) (violation *PolicyViolation, parsed *ParsedQuery) {
 	parsed = ParseQuery(query)
 	defer func() {
 		if r := recover(); r != nil {
@@ -833,7 +859,7 @@ func safeCheckQuery(pe *PolicyEngine, identity *AgentIdentity, query string) (vi
 			violation = nil
 		}
 	}()
-	violation = pe.CheckQueryWithParsed(identity, parsed, query, 0)
+	violation = pe.CheckQueryWithContext(identity, parsed, query, 0, ctx)
 	return
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -232,10 +232,17 @@ func handleProxyConn(client net.Conn, upstreamAddr string, pe *PolicyEngine, tls
 		return
 	}
 
-	// 5. Relay auth handshake until ReadyForQuery ('Z')
-	if err := relayAuth(client, upstream); err != nil {
+	// 5. Relay auth handshake until ReadyForQuery ('Z'). Capture the
+	// upstream backend PID (from BackendKeyData) so REAL-F9 can tell
+	// proxy-originated sessions from direct-to-DB bypasses.
+	upstreamPID, err := relayAuth(client, upstream)
+	if err != nil {
 		log.Printf("Proxy: auth relay failed for agent=%s: %v", agentLabel, err)
 		return
+	}
+	if upstreamPID > 0 {
+		proxyBackendRegistry.Register(upstreamPID)
+		defer proxyBackendRegistry.Deregister(upstreamPID)
 	}
 
 	// 6. Main proxy loop
@@ -299,25 +306,33 @@ func indexOf(b []byte, v byte) int {
 	return -1
 }
 
-// relayAuth relays messages between client and upstream during auth handshake.
-func relayAuth(client, upstream net.Conn) error {
+// relayAuth relays messages between client and upstream during auth
+// handshake. Returns the upstream backend PID parsed from BackendKeyData
+// ('K'), or 0 if not seen — used by REAL-F9 bypass detection to track
+// which sessions the proxy has originated.
+func relayAuth(client, upstream net.Conn) (int, error) {
+	upstreamPID := 0
 	for {
 		// Read message from upstream (server)
 		msgType, payload, err := readWireMessage(upstream)
 		if err != nil {
-			return fmt.Errorf("reading upstream auth message: %w", err)
+			return upstreamPID, fmt.Errorf("reading upstream auth message: %w", err)
 		}
 
 		// Forward to client
 		if err := writeWireMessage(client, msgType, payload); err != nil {
-			return fmt.Errorf("forwarding auth to client: %w", err)
+			return upstreamPID, fmt.Errorf("forwarding auth to client: %w", err)
 		}
 
 		switch msgType {
+		case 'K': // BackendKeyData — first 4 bytes are the upstream PID.
+			if len(payload) >= 4 {
+				upstreamPID = int(binary.BigEndian.Uint32(payload[:4]))
+			}
 		case 'Z': // ReadyForQuery — auth complete
-			return nil
+			return upstreamPID, nil
 		case 'E': // ErrorResponse from upstream
-			return fmt.Errorf("upstream rejected connection")
+			return upstreamPID, fmt.Errorf("upstream rejected connection")
 		case 'R': // Authentication message
 			if len(payload) >= 4 {
 				authType := binary.BigEndian.Uint32(payload[:4])
@@ -326,15 +341,15 @@ func relayAuth(client, upstream net.Conn) error {
 				if authType != 0 && authType != 12 {
 					cType, cPayload, cErr := readWireMessage(client)
 					if cErr != nil {
-						return fmt.Errorf("reading client auth response: %w", cErr)
+						return upstreamPID, fmt.Errorf("reading client auth response: %w", cErr)
 					}
 					if wErr := writeWireMessage(upstream, cType, cPayload); wErr != nil {
-						return fmt.Errorf("forwarding client auth to upstream: %w", wErr)
+						return upstreamPID, fmt.Errorf("forwarding client auth to upstream: %w", wErr)
 					}
 				}
 			}
 		}
-		// ParameterStatus ('S'), BackendKeyData ('K'), etc. — already forwarded
+		// ParameterStatus ('S'), etc. — already forwarded
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -194,13 +194,26 @@ func handleProxyConn(client net.Conn, upstreamAddr string, pe *PolicyEngine, tls
 	if identity != nil {
 		cfg := pe.GetConfig()
 		if cfg != nil {
-			if ap, ok := cfg.Agents[identity.AgentID]; ok && ap.AuthToken != "" {
-				if identity.Token == "" || identity.Token != ap.AuthToken {
+			ap, ok := cfg.Agents[identity.AgentID]
+			agentHasToken := ok && ap.AuthToken != ""
+			tokensMatch := agentHasToken && identity.Token == ap.AuthToken
+			if agentHasToken {
+				if identity.Token == "" || !tokensMatch {
 					log.Printf("%s%s[BLOCKED]%s auth token mismatch for agent=%s",
 						colorRed, colorBold, colorReset, agentLabel)
 					sendStartupError(client, "auth token mismatch for agent: "+identity.AgentID)
 					return
 				}
+			}
+			// F3 enforcement: when the require_auth_token guard is on
+			// (and the self-check confirmed it works), an agent that
+			// presents an identity with no verified token is rejected
+			// fail-safe closed. Disabled by default; warn-only otherwise.
+			if requireAuthTokenEnforce(identity, agentHasToken, tokensMatch) {
+				log.Printf("%s%s[BLOCKED]%s require_auth_token=true: agent=%s has no verified auth_token",
+					colorRed, colorBold, colorReset, agentLabel)
+				sendStartupError(client, "require_auth_token=true: agent has no verified auth_token: "+identity.AgentID)
+				return
 			}
 		}
 	}

--- a/searchpath.go
+++ b/searchpath.go
@@ -1,0 +1,361 @@
+package main
+
+// REAL F2 — per-connection search_path tracking.
+//
+// The shipped F2 (see guards.go: unqualifiedAllowNormalizationOn) hard-codes
+// "public" as the default schema for unqualified ALLOW matches. That is
+// correct only when the agent never changes search_path. If an agent issues
+// `SET search_path TO myschema` (or a multi-schema list), an unqualified
+// `feedback` resolves server-side to `myschema.feedback`, but the shipped
+// path normalizes to `public.feedback` — which either over-blocks (a
+// `myschema.*` mission) or under-validates (a `public.*` mission would
+// allow it even though Postgres will run it against `myschema`).
+//
+// This file tracks search_path PER CONNECTION (the proxyQueryLoop scope is
+// already one goroutine per connection — the right granularity) and threads
+// the current list into CheckQuery. The behavior is gated by
+// `searchPathAwareAllowOn`. Self-check failure → gate stays OFF and the
+// proxy falls back to the shipped, public-only F2 normalization (which is
+// itself guarded). Fail-safe = closed.
+
+import (
+	"log"
+	"strings"
+	"sync/atomic"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-connection state
+// ─────────────────────────────────────────────────────────────────────────────
+
+// SearchPathState is the per-connection search_path the proxy has observed.
+// It is updated as the connection issues `SET search_path`/`RESET
+// search_path` statements; the policy check reads it on every query.
+//
+// Default (no SET seen): []string{"public"} — Postgres' factory default for
+// most setups. We deliberately do not try to read the role's
+// configured-default search_path: that would require querying the DB at
+// connect time and a stale answer is worse than this conservative default.
+// (See caveats in the report.)
+type SearchPathState struct {
+	schemas []string
+}
+
+// NewSearchPathState returns the connection's initial search_path.
+func NewSearchPathState() *SearchPathState {
+	return &SearchPathState{schemas: []string{"public"}}
+}
+
+// Schemas returns a copy-safe view of the current search_path. We return the
+// underlying slice (callers must NOT mutate); the parser always allocates a
+// fresh slice when it updates the state, so reads are stable.
+func (s *SearchPathState) Schemas() []string {
+	if s == nil {
+		return []string{"public"}
+	}
+	return s.schemas
+}
+
+// Reset returns the search_path to the default. Mirrors `RESET search_path`
+// or `SET search_path TO DEFAULT`.
+func (s *SearchPathState) Reset() {
+	s.schemas = []string{"public"}
+}
+
+// Set installs a new ordered schema list. A nil/empty list resets to default.
+func (s *SearchPathState) Set(schemas []string) {
+	if len(schemas) == 0 {
+		s.Reset()
+		return
+	}
+	cp := make([]string, 0, len(schemas))
+	for _, sc := range schemas {
+		sc = strings.TrimSpace(sc)
+		if sc == "" {
+			continue
+		}
+		cp = append(cp, sc)
+	}
+	if len(cp) == 0 {
+		s.Reset()
+		return
+	}
+	s.schemas = cp
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SET search_path parser
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ApplySearchPathStatement inspects a query for `SET search_path …` or
+// `RESET search_path` semantics. If the query is a search_path mutation,
+// the receiver is updated in place and the function returns true. Otherwise
+// the receiver is unchanged and the function returns false.
+//
+// Behavior:
+//   - `SET search_path TO a, b;`         → ["a", "b"]
+//   - `SET search_path = "MyS", public;` → ["MyS", "public"] (quoted ident
+//                                          preserves case)
+//   - `SET search_path TO DEFAULT`       → reset
+//   - `RESET search_path`                → reset
+//   - `SET LOCAL search_path TO …`       → applied (we treat LOCAL the same;
+//                                          the proxy isn't transaction-aware
+//                                          enough to scope it; conservative)
+//   - `$user` token                      → kept as-is. We don't know the
+//                                          server's `current_user`, so we
+//                                          can't expand it; matching falls
+//                                          through to the next entry.
+//   - any other query                    → returns false, no change.
+//
+// Identifiers fold to lowercase Postgres-style when unquoted; quoted
+// identifiers preserve case (we only strip the surrounding quotes). Schema
+// matching downstream is case-insensitive, so the case preservation is
+// cosmetic for the policy decision but kept so logs reflect what was
+// actually requested.
+func (s *SearchPathState) ApplySearchPathStatement(query string) bool {
+	if s == nil {
+		return false
+	}
+	trimmed := strings.TrimSpace(query)
+	// Strip any trailing semicolons/whitespace.
+	trimmed = strings.TrimRight(trimmed, "; \t\r\n")
+	if trimmed == "" {
+		return false
+	}
+	upper := strings.ToUpper(trimmed)
+
+	// `RESET search_path`
+	if strings.HasPrefix(upper, "RESET ") {
+		rest := strings.TrimSpace(trimmed[len("RESET "):])
+		if strings.EqualFold(rest, "search_path") {
+			s.Reset()
+			return true
+		}
+		return false
+	}
+
+	if !strings.HasPrefix(upper, "SET ") {
+		return false
+	}
+	// Drop "SET " (case-preserving).
+	rest := strings.TrimSpace(trimmed[4:])
+	upRest := strings.ToUpper(rest)
+	// Optional LOCAL/SESSION qualifier.
+	if strings.HasPrefix(upRest, "LOCAL ") {
+		rest = strings.TrimSpace(rest[len("LOCAL "):])
+	} else if strings.HasPrefix(upRest, "SESSION ") {
+		rest = strings.TrimSpace(rest[len("SESSION "):])
+	}
+	upRest = strings.ToUpper(rest)
+	if !strings.HasPrefix(upRest, "SEARCH_PATH") {
+		return false
+	}
+	rest = strings.TrimSpace(rest[len("SEARCH_PATH"):])
+	// Allow either `TO` or `=` between the name and the value.
+	upRest = strings.ToUpper(rest)
+	switch {
+	case strings.HasPrefix(upRest, "TO "):
+		rest = strings.TrimSpace(rest[3:])
+	case strings.HasPrefix(upRest, "TO\t"):
+		rest = strings.TrimSpace(rest[3:])
+	case strings.HasPrefix(rest, "="):
+		rest = strings.TrimSpace(rest[1:])
+	default:
+		// `SET search_path` with no value is malformed — leave state alone.
+		return false
+	}
+
+	// `DEFAULT` keyword resets the path.
+	if strings.EqualFold(rest, "DEFAULT") {
+		s.Reset()
+		return true
+	}
+
+	schemas := parseSearchPathList(rest)
+	s.Set(schemas)
+	return true
+}
+
+// parseSearchPathList splits the right-hand side of a `SET search_path TO`
+// statement into individual schema tokens. Handles quoted identifiers
+// ("Foo Bar"), the special `$user` placeholder, and stray whitespace.
+func parseSearchPathList(s string) []string {
+	out := []string{}
+	i := 0
+	for i < len(s) {
+		// skip whitespace + commas
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == ',') {
+			i++
+		}
+		if i >= len(s) {
+			break
+		}
+		if s[i] == '"' {
+			// Quoted identifier — read until the matching unescaped quote.
+			i++
+			start := i
+			for i < len(s) && s[i] != '"' {
+				i++
+			}
+			out = append(out, s[start:i])
+			if i < len(s) {
+				i++ // consume closing quote
+			}
+			continue
+		}
+		// Unquoted token — read until comma/whitespace.
+		start := i
+		for i < len(s) && s[i] != ',' && s[i] != ' ' && s[i] != '\t' {
+			i++
+		}
+		tok := s[start:i]
+		if tok == "" {
+			continue
+		}
+		// `$user` is a placeholder we cannot expand without querying the
+		// DB; preserve it as-is (callers skip it during matching).
+		if !strings.EqualFold(tok, "$user") {
+			tok = strings.ToLower(tok) // unquoted identifiers fold to lower
+		}
+		out = append(out, tok)
+	}
+	return out
+}
+
+// IsSearchPathStatement is a cheap predicate the proxy uses to decide
+// whether to bother feeding a query to ApplySearchPathStatement. It only
+// peeks at the leading keyword. False positives are fine; false negatives
+// would silently miss a mutation.
+func IsSearchPathStatement(query string) bool {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return false
+	}
+	q = strings.ToUpper(q)
+	// We must catch SET LOCAL/SESSION search_path forms too.
+	if strings.HasPrefix(q, "RESET ") {
+		return strings.Contains(q, "SEARCH_PATH")
+	}
+	if !strings.HasPrefix(q, "SET ") {
+		return false
+	}
+	return strings.Contains(q, "SEARCH_PATH")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Guard for the search-path-aware ALLOW match
+// ─────────────────────────────────────────────────────────────────────────────
+
+// searchPathAwareAllowOn gates the search-path-aware ALLOW path. Default
+// OFF; flipped ON only after InitSearchPathAwareAllowGuard's self-check
+// agrees with the contract.
+//
+// When OFF: the proxy falls back to the shipped F2 normalization (always
+// "public.<name>" for unqualified ALLOW matches). That fallback is itself
+// guarded by unqualifiedAllowNormalizationOn — so a search-path-aware
+// self-check failure does NOT regress to the pre-F2 over-block; it just
+// loses the per-connection precision.
+//
+// When ON: isTableAllowedWithContext (in policy.go) normalizes an
+// unqualified table name against the connection's CURRENT search_path:
+// for each schema in order, try `<schema>.<name>` against the allow list;
+// if any matches, allow.
+var searchPathAwareAllowOn atomic.Bool
+
+// IsSearchPathAwareAllowOn reports the current gate state.
+func IsSearchPathAwareAllowOn() bool { return searchPathAwareAllowOn.Load() }
+
+// setSearchPathAwareAllow is the test-only seam for flipping the gate
+// without going through the self-check.
+func setSearchPathAwareAllow(on bool) { searchPathAwareAllowOn.Store(on) }
+
+// searchPathAwareAllowSelfCheckPassFn is the test-only seam used by the
+// failure-path test in searchpath_test.go. Production assigns the real
+// candidate-pass function below.
+var searchPathAwareAllowSelfCheckPassFn = searchPathAwareAllowSelfCheckPass
+
+// InitSearchPathAwareAllowGuard runs the self-check and engages the gate
+// only on contract agreement. Six contracts (mirror of the spec):
+//
+//  1. search_path=["public"], bare "feedback" matches allow ["public.*"]
+//  2. search_path=["myschema"], bare "feedback" matches allow ["myschema.*"]
+//  3. search_path=["myschema"], bare "feedback" does NOT match allow
+//     ["public.users"]
+//  4. search_path=["myschema","public"], bare "feedback" matches allow
+//     ["public.feedback"] (resolves via the second entry)
+//  5. BLOCK: search_path=["secret"], bare "keys" is BLOCKED when blocklist
+//     has "secret.keys" (we do not loosen blocking)
+//  6. parser: `SET search_path TO a, b;` → ["a","b"]; `RESET search_path`
+//     → default; `SET search_path TO DEFAULT` → default.
+//
+// Failure → gate OFF + WARNING + fall back to the shipped public-only F2
+// (which is itself a guarded improvement over pre-F2). Never crashes.
+func InitSearchPathAwareAllowGuard() {
+	// The self-check itself flips the gate ON during contract probing
+	// (because isTableAllowedWithContext only consults search_path when
+	// IsSearchPathAwareAllowOn() is true). We tentatively enable, run
+	// the probe, and either confirm or revert.
+	prev := searchPathAwareAllowOn.Load()
+	searchPathAwareAllowOn.Store(true)
+	if !searchPathAwareAllowSelfCheckPassFn() {
+		searchPathAwareAllowOn.Store(false)
+		_ = prev
+		log.Printf("⚠️  REAL-F2 self-check FAILED: per-connection search_path tracking disabled. "+
+			"Falling back to shipped F2 (public-only ALLOW normalization, guard=%v). "+
+			"Agents that issue `SET search_path TO <non-public>` may be over-blocked or "+
+			"under-validated. This is fail-safe (closed): we keep the prior, validated behavior "+
+			"rather than silently shipping a broken search_path-aware path.",
+			IsUnqualifiedAllowNormalizationOn())
+		return
+	}
+	searchPathAwareAllowOn.Store(true)
+	log.Printf("✅ REAL-F2 guard active: per-connection search_path is tracked and used for " +
+		"unqualified ALLOW matching (BLOCK matching is unchanged — still considers all " +
+		"schemas in search_path). Default search_path is [\"public\"] until the agent " +
+		"issues SET search_path.")
+}
+
+// searchPathAwareAllowSelfCheckPass exercises the six contracts. We use
+// the policy package's isTableAllowedWithContext directly (see policy.go),
+// passing normalize=true and a synthetic schema context, so the self-check
+// validates the production matcher rather than a stub.
+func searchPathAwareAllowSelfCheckPass() bool {
+	// (1)
+	if !isTableAllowedWithContext("feedback", []string{"public.*"}, true, []string{"public"}) {
+		return false
+	}
+	// (2)
+	if !isTableAllowedWithContext("feedback", []string{"myschema.*"}, true, []string{"myschema"}) {
+		return false
+	}
+	// (3)
+	if isTableAllowedWithContext("feedback", []string{"public.users"}, true, []string{"myschema"}) {
+		return false
+	}
+	// (4)
+	if !isTableAllowedWithContext("feedback", []string{"public.feedback"}, true, []string{"myschema", "public"}) {
+		return false
+	}
+	// (5) BLOCK path is unchanged but we double-check: search_path can
+	// include a schema that the blocklist names; an unqualified bare name
+	// must still be caught when it could resolve to that blocked schema.
+	if !isTableBlockedWithContext("keys", []string{"secret.keys"}, []string{"secret"}) {
+		return false
+	}
+	// (6) parser smoke tests
+	st := NewSearchPathState()
+	if ok := st.ApplySearchPathStatement("SET search_path TO a, b;"); !ok ||
+		len(st.Schemas()) != 2 || st.Schemas()[0] != "a" || st.Schemas()[1] != "b" {
+		return false
+	}
+	if ok := st.ApplySearchPathStatement("RESET search_path"); !ok ||
+		len(st.Schemas()) != 1 || st.Schemas()[0] != "public" {
+		return false
+	}
+	st.Set([]string{"x"})
+	if ok := st.ApplySearchPathStatement("SET search_path TO DEFAULT"); !ok ||
+		len(st.Schemas()) != 1 || st.Schemas()[0] != "public" {
+		return false
+	}
+	return true
+}

--- a/searchpath_test.go
+++ b/searchpath_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// REAL-F2: search_path-aware ALLOW path
+// ─────────────────────────────────────────────────────────────────────────────
+
+// withRealF2 toggles the gate around fn and restores prior state.
+func withRealF2(t *testing.T, on bool, fn func()) {
+	t.Helper()
+	prev := IsSearchPathAwareAllowOn()
+	defer setSearchPathAwareAllow(prev)
+	setSearchPathAwareAllow(on)
+	// Shipped F2 must be ON for the search-path path to consult the
+	// schema list at all (the gate is only consulted when normalize=true
+	// or when the unqualified table reaches isTableAllowedWithContext via
+	// CheckQuery — which always passes the live shipped flag). We toggle
+	// it explicitly to keep tests self-contained.
+	prevShipped := IsUnqualifiedAllowNormalizationOn()
+	defer setUnqualifiedAllowNormalization(prevShipped)
+	setUnqualifiedAllowNormalization(true)
+	fn()
+}
+
+// (1) search_path=["public"], bare "feedback" matches allow ["public.*"].
+func TestRealF2_Contract1_PublicSearchPath_PublicStarAllow(t *testing.T) {
+	withRealF2(t, true, func() {
+		if !isTableAllowedWithContext("feedback", []string{"public.*"}, true, []string{"public"}) {
+			t.Error("contract 1: bare 'feedback' must match allow=[public.*] with search_path=[public]")
+		}
+	})
+}
+
+// (2) search_path=["myschema"], bare "feedback" matches allow ["myschema.*"].
+func TestRealF2_Contract2_NonPublicSearchPath_MatchingSchemaStarAllow(t *testing.T) {
+	withRealF2(t, true, func() {
+		if !isTableAllowedWithContext("feedback", []string{"myschema.*"}, true, []string{"myschema"}) {
+			t.Error("contract 2: bare 'feedback' must match allow=[myschema.*] with search_path=[myschema]")
+		}
+	})
+}
+
+// (3) search_path=["myschema"], bare "feedback" does NOT match ["public.users"].
+func TestRealF2_Contract3_NonPublicSearchPath_PublicUsersOnly(t *testing.T) {
+	withRealF2(t, true, func() {
+		if isTableAllowedWithContext("feedback", []string{"public.users"}, true, []string{"myschema"}) {
+			t.Error("contract 3: bare 'feedback' must NOT match allow=[public.users] with search_path=[myschema]")
+		}
+	})
+}
+
+// (4) search_path=["myschema","public"], bare "feedback" matches allow
+// ["public.feedback"] via the second entry.
+func TestRealF2_Contract4_SecondEntryResolves(t *testing.T) {
+	withRealF2(t, true, func() {
+		if !isTableAllowedWithContext("feedback", []string{"public.feedback"}, true, []string{"myschema", "public"}) {
+			t.Error("contract 4: search_path=[myschema,public] must allow 'feedback' via public.feedback")
+		}
+	})
+}
+
+// (5) BLOCK path: search_path=["secret"], bare "keys" must still be blocked
+// when blocklist contains "secret.keys". This proves we never loosen
+// blocking through the search-path-aware path.
+func TestRealF2_Contract5_BlockNotLoosened(t *testing.T) {
+	withRealF2(t, true, func() {
+		if !isTableBlockedWithContext("keys", []string{"secret.keys"}, []string{"secret"}) {
+			t.Error("contract 5: bare 'keys' must remain blocked under blocklist=[secret.keys] with search_path=[secret]")
+		}
+	})
+}
+
+// (6) parser smoke tests.
+func TestRealF2_Contract6_Parser(t *testing.T) {
+	st := NewSearchPathState()
+	if !reflect.DeepEqual(st.Schemas(), []string{"public"}) {
+		t.Fatalf("default search_path should be [public], got %v", st.Schemas())
+	}
+	if !st.ApplySearchPathStatement("SET search_path TO a, b;") {
+		t.Fatal("expected SET search_path TO a, b to be recognized")
+	}
+	if !reflect.DeepEqual(st.Schemas(), []string{"a", "b"}) {
+		t.Fatalf("expected [a b], got %v", st.Schemas())
+	}
+	if !st.ApplySearchPathStatement("RESET search_path") {
+		t.Fatal("expected RESET search_path to be recognized")
+	}
+	if !reflect.DeepEqual(st.Schemas(), []string{"public"}) {
+		t.Fatalf("RESET should return to [public], got %v", st.Schemas())
+	}
+	st.Set([]string{"x"})
+	if !st.ApplySearchPathStatement("SET search_path TO DEFAULT") {
+		t.Fatal("expected SET search_path TO DEFAULT to be recognized")
+	}
+	if !reflect.DeepEqual(st.Schemas(), []string{"public"}) {
+		t.Fatalf("DEFAULT should restore [public], got %v", st.Schemas())
+	}
+}
+
+// Parser: quoted identifiers preserve case. The matching downstream is
+// case-insensitive but the parser must keep the user's spelling.
+func TestRealF2_Parser_QuotedIdent(t *testing.T) {
+	st := NewSearchPathState()
+	st.ApplySearchPathStatement(`SET search_path TO "MySchema", "mixed Case"`)
+	got := st.Schemas()
+	want := []string{"MySchema", "mixed Case"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("quoted ident parse: got %v want %v", got, want)
+	}
+}
+
+// Parser: `$user` is preserved; matching skips it.
+func TestRealF2_Parser_DollarUser(t *testing.T) {
+	st := NewSearchPathState()
+	st.ApplySearchPathStatement(`SET search_path TO "$user", public`)
+	got := st.Schemas()
+	if len(got) != 2 || !strings.EqualFold(got[0], "$user") || got[1] != "public" {
+		t.Errorf("$user parse: got %v want [$user public]", got)
+	}
+	// And the matcher must skip $user gracefully and still find public.feedback.
+	withRealF2(t, true, func() {
+		if !isTableAllowedWithContext("feedback", []string{"public.feedback"}, true, got) {
+			t.Error("$user entry should be skipped, fallthrough to public must allow feedback")
+		}
+	})
+}
+
+// Parser: SET with `=` operator and SET LOCAL/SESSION qualifiers.
+func TestRealF2_Parser_VariantSyntax(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"SET search_path = a", []string{"a"}},
+		{"SET LOCAL search_path TO a, b", []string{"a", "b"}},
+		{"SET SESSION search_path TO c", []string{"c"}},
+		{"set search_path to A, B;", []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		st := NewSearchPathState()
+		if !st.ApplySearchPathStatement(tc.in) {
+			t.Errorf("expected %q recognized", tc.in)
+			continue
+		}
+		if !reflect.DeepEqual(st.Schemas(), tc.want) {
+			t.Errorf("%q → %v, want %v", tc.in, st.Schemas(), tc.want)
+		}
+	}
+}
+
+// Parser: non-search_path queries leave state untouched.
+func TestRealF2_Parser_NonMatchingQuery(t *testing.T) {
+	st := NewSearchPathState()
+	if st.ApplySearchPathStatement("SELECT * FROM feedback") {
+		t.Error("SELECT must not be treated as a search_path mutation")
+	}
+	if st.ApplySearchPathStatement("SET application_name = 'x'") {
+		t.Error("SET application_name must not be treated as a search_path mutation")
+	}
+	if !reflect.DeepEqual(st.Schemas(), []string{"public"}) {
+		t.Errorf("state should be untouched, got %v", st.Schemas())
+	}
+}
+
+// Fallback: gate OFF → behaves like shipped F2 (public-only normalization).
+// search_path=["myschema"] is ignored; bare "feedback" matches "public.*"
+// (because shipped F2 normalizes to public.feedback) and does NOT match
+// "myschema.*" (the search-path-aware lookup is gated).
+func TestRealF2_Fallback_GateOffBehavesLikeShippedF2(t *testing.T) {
+	withRealF2(t, false, func() {
+		// shipped F2 still normalizes to public.feedback for ALLOW
+		if !isTableAllowedWithContext("feedback", []string{"public.*"}, true, []string{"myschema"}) {
+			t.Error("gate OFF: shipped F2 should still allow feedback under public.* (public-only normalization)")
+		}
+		// search-path-aware match must NOT happen when gate is OFF
+		if isTableAllowedWithContext("feedback", []string{"myschema.*"}, true, []string{"myschema"}) {
+			t.Error("gate OFF: search-path-aware match must NOT engage")
+		}
+	})
+}
+
+// Fallback: with REAL-F2 OFF, the BLOCK path does not consider extra
+// search_path schemas (it remains exactly the shipped behavior).
+func TestRealF2_Fallback_BlockPathUnchanged(t *testing.T) {
+	withRealF2(t, false, func() {
+		// Without the gate, `keys` does not get cross-checked against
+		// `secret.keys` via the search_path. Schema-agnostic match still
+		// catches it though (legacy isTableBlocked behavior). Use a
+		// blocklist that ONLY hits via the schema search to prove the
+		// fallback does not engage.
+		if isTableBlockedWithContext("public_keys_only_name", []string{"secret.public_keys_only_name"}, []string{"secret"}) {
+			// The schema-agnostic leaf match in isTableBlocked already
+			// catches "public_keys_only_name" against "secret.public_keys_only_name"
+			// (leaf == leaf). So this test would always pass — but it
+			// passes for the WRONG reason in fallback mode (legacy
+			// schema-agnostic match), and for the right reason when the
+			// gate is on. Document this with a non-leaf-collision case
+			// below.
+		}
+		// A blocklist of "secret.somesecret" plus a query for "keys" — no
+		// leaf collision, no schema-agnostic match. Without REAL-F2, this
+		// must NOT block.
+		if isTableBlockedWithContext("keys", []string{"secret.somesecret"}, []string{"secret"}) {
+			t.Error("gate OFF: 'keys' must not block under blocklist=[secret.somesecret] (no leaf collision)")
+		}
+	})
+	withRealF2(t, true, func() {
+		// With REAL-F2 ON, the same query against a same-leaf blocklist
+		// still works the same way (leaf-collision still catches it):
+		if !isTableBlockedWithContext("keys", []string{"secret.keys"}, []string{"secret"}) {
+			t.Error("gate ON: 'keys' must block under blocklist=[secret.keys] with search_path=[secret]")
+		}
+	})
+}
+
+// Self-check engages the guard on the canonical happy case and
+// fallback-disables it when the contract breaks.
+func TestRealF2_SelfCheckEngagesGuard(t *testing.T) {
+	prev := IsSearchPathAwareAllowOn()
+	defer setSearchPathAwareAllow(prev)
+	setSearchPathAwareAllow(false)
+	out := captureLog(t, func() { InitSearchPathAwareAllowGuard() })
+	if !IsSearchPathAwareAllowOn() {
+		t.Fatalf("self-check should pass on the canonical case — guard expected ON. log: %s", out)
+	}
+	if !strings.Contains(out, "REAL-F2 guard active") {
+		t.Errorf("expected REAL-F2 guard-active log, got: %s", out)
+	}
+}
+
+// Self-check failure path: inject a broken candidate-pass function via
+// the test seam. The init function must flip the gate OFF and emit a
+// clear WARNING; the proxy then falls back to shipped F2.
+func TestRealF2_SelfCheckFailureFallsBack(t *testing.T) {
+	prev := IsSearchPathAwareAllowOn()
+	defer setSearchPathAwareAllow(prev)
+	setSearchPathAwareAllow(true) // start ON to prove fallback flips it OFF
+
+	// Inject a broken self-check seam: temporarily replace the
+	// candidate-pass function via a known package-level seam. We expose
+	// one for the test specifically so production code stays clean.
+	prevSeam := searchPathAwareAllowSelfCheckPassFn
+	defer func() { searchPathAwareAllowSelfCheckPassFn = prevSeam }()
+	searchPathAwareAllowSelfCheckPassFn = func() bool { return false }
+
+	out := captureLog(t, func() { InitSearchPathAwareAllowGuard() })
+	if IsSearchPathAwareAllowOn() {
+		t.Fatalf("broken self-check must DISABLE REAL-F2 guard. log: %s", out)
+	}
+	if !strings.Contains(out, "REAL-F2 self-check FAILED") {
+		t.Errorf("expected REAL-F2 self-check FAILED warning, got: %s", out)
+	}
+}
+
+// End-to-end through CheckQueryWithContext: SET search_path TO myschema
+// followed by SELECT from feedback is allowed under a myschema.* mission
+// and blocked under a public.*-only mission.
+func TestRealF2_EndToEnd_SearchPathThenSelect(t *testing.T) {
+	prev := IsSearchPathAwareAllowOn()
+	prevShipped := IsUnqualifiedAllowNormalizationOn()
+	defer func() {
+		setSearchPathAwareAllow(prev)
+		setUnqualifiedAllowNormalization(prevShipped)
+	}()
+	setSearchPathAwareAllow(true)
+	setUnqualifiedAllowNormalization(true)
+
+	make := func(missionTables []string) *PolicyEngine {
+		return &PolicyEngine{
+			config: &PolicyConfig{
+				DefaultPolicy: "allow",
+				Agents: map[string]AgentPolicy{
+					"orm-agent": {
+						AuthToken: "tok",
+						Missions: map[string]MissionPolicy{
+							"read": {Tables: missionTables},
+						},
+					},
+				},
+				Unidentified: UnidentifiedPolicy{Policy: "deny"},
+			},
+			enforcement: "enforce",
+		}
+	}
+	id := &AgentIdentity{AgentID: "orm-agent", MissionID: "read", Token: "tok"}
+
+	// agent SET search_path TO myschema → tracked
+	st := NewSearchPathState()
+	st.ApplySearchPathStatement("SET search_path TO myschema")
+
+	// (a) Allowed under myschema.*
+	pe := make([]string{"myschema.*"})
+	v := pe.CheckQueryWithContext(id, ParseQuery("SELECT * FROM feedback"), "SELECT * FROM feedback", 0, &QueryContext{SearchPath: st.Schemas()})
+	if v != nil && v.Reason == "table_not_in_mission" {
+		t.Errorf("e2e (a): myschema.* must allow unqualified feedback under search_path=[myschema], got %+v", v)
+	}
+
+	// (b) Blocked under public.* only
+	pe2 := make([]string{"public.*"})
+	v2 := pe2.CheckQueryWithContext(id, ParseQuery("SELECT * FROM feedback"), "SELECT * FROM feedback", 0, &QueryContext{SearchPath: st.Schemas()})
+	if v2 == nil || v2.Reason != "table_not_in_mission" {
+		t.Errorf("e2e (b): public.*-only must block unqualified feedback under search_path=[myschema], got %+v", v2)
+	}
+}
+
+// Backward compatibility: the existing CheckQuery / CheckQueryWithParsed
+// callers (no QueryContext) still behave as the shipped F2 does.
+func TestRealF2_BackwardCompat_NilContext(t *testing.T) {
+	prev := IsSearchPathAwareAllowOn()
+	prevShipped := IsUnqualifiedAllowNormalizationOn()
+	defer func() {
+		setSearchPathAwareAllow(prev)
+		setUnqualifiedAllowNormalization(prevShipped)
+	}()
+	setSearchPathAwareAllow(true)
+	setUnqualifiedAllowNormalization(true)
+
+	pe := &PolicyEngine{
+		config: &PolicyConfig{
+			DefaultPolicy: "allow",
+			Agents: map[string]AgentPolicy{
+				"orm-agent": {
+					AuthToken: "tok",
+					Missions: map[string]MissionPolicy{
+						"read": {Tables: []string{"public.*"}},
+					},
+				},
+			},
+			Unidentified: UnidentifiedPolicy{Policy: "deny"},
+		},
+		enforcement: "enforce",
+	}
+	id := &AgentIdentity{AgentID: "orm-agent", MissionID: "read", Token: "tok"}
+	// No QueryContext (legacy CheckQuery): public-only fallback applies,
+	// bare feedback under public.* must be allowed (the shipped F2 fix).
+	if v := pe.CheckQuery(id, "SELECT * FROM feedback", 0); v != nil && v.Reason == "table_not_in_mission" {
+		t.Errorf("backward-compat: legacy CheckQuery must still allow bare feedback under public.*, got %+v", v)
+	}
+}


### PR DESCRIPTION
Three client-blocking security findings, each fixed with a self-disabling guard (gate defaults safe, startup self-check flips it on, falls back to prior safe behavior + WARNING if the check fails).

**F2 — unqualified-name over-block (real fix).** Per-connection `search_path` tracking. Unqualified table refs (e.g. `feedback`) now resolve against the agent's actual search_path instead of a hard-coded `public`. Handles multi-schema lists, quoted idents, `$user`, `RESET`/`DEFAULT`, `SET LOCAL/SESSION`. BLOCK path is widened across all search_path schemas — never loosened. Falls back to the shipped public-only normalization if the guard self-check fails.

**F3 — spoofable identity.** Always emits one loud startup warning counting agents with no `auth_token` (identity via `application_name` is spoofable). Optional `FW_REQUIRE_AUTH_TOKEN=true` makes tokenless agents fail-closed; self-check proves the enforcer actually rejects a tokenless identity, else falls back to warn-only.

**F9 — DB-port isolation (real fix).** Runtime bypass detection: reconciles proxy-originated backend PIDs against `pg_stat_activity` and warns when an agent session reached the DB without going through the proxy (the actual void-the-promise condition). Observe-and-alert only, deduped per PID. Non-fatal on query error. Disable via `FW_BYPASS_DETECTION=false`. The earlier single-host TCP probe stays as a topology hint.

Verified locally: `go build .` clean; `go test .` + `./internal/...` + `./policygen/...` green; 51 guard tests pass (healthy + fallback paths for each fix), 0 failures. (`cmd/testparse` has a pre-existing unrelated build error on main.)

Caveats documented in /tmp/three_fixes_report.md: role-level search_path defaults aren't visible without querying; F9 correlation has known false-pos/neg edges (documented).